### PR TITLE
An inspector view for the next-generation GToolkit

### DIFF
--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -773,6 +773,27 @@ DataFrame >> gtInspectorItemsIn: composite [
 		when: [ false ].
 ]
 
+{ #category : #'gt-inspector-extension' }
+DataFrame >> gtTableFor: aView [
+	<gtView>
+	"A table view for the next-generation GToolkit."
+	| aList |
+
+	aList := aView columnedList
+		title: 'Table' translated;
+		priority: 10;
+		items: [ self asArrayOfRows ].
+
+	self columnNames do:
+		[ :cn |
+			aList column
+				title: cn;
+				matchParent;
+				item: [ :each | each at: cn ] ].
+	
+	^ aList
+]
+
 { #category : #accessing }
 DataFrame >> head [ 
 


### PR DESCRIPTION
A basic inspector plugin for the next-generation [GToolkit](https://gtoolkit.com/). Since it doesn't actually create a dependency on that package, I think it is safe to add to the DataFrame package, but creating a separate package is also a possibility of course.