### PR TITLE
94-Selecting-a-row-on-GTInspector-raises-an-error

### DIFF
--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -1187,7 +1187,7 @@ DataFrame >> showWithGlamourIn: composite [
 		intercellSpacing: 1;
 		dataSource: (DataFrameFTData elements: self);
 		onAnnouncement: FTSelectionChanged
-			do: [ :ann | (self rowAt: ann newSelectedIndexes first) inspect ].
+			do: [ :ann | (self rowAt: ann newSelectedRowIndexes first) inspect ].
 
 	"		onAnnouncement: FTSelectionChanged 
 			do: [ :ann | (self rowsAt: ann newSelectedRowIndexes) gtInspectorItemsIn: composite ];"


### PR DESCRIPTION
Fixes an error of selecting a row in a GTInspector.