### PR TITLE
Added ability to remove nil from DataFrame and Series

### DIFF
--- a/src/DataFrame-Tests/DataFrameInternalTest.class.st
+++ b/src/DataFrame-Tests/DataFrameInternalTest.class.st
@@ -1,4 +1,4 @@
-Class { 
+Class {
 	#name : #DataFrameInternalTest,
 	#superclass : #TestCase,
 	#instVars : [
@@ -302,6 +302,28 @@ DataFrameInternalTest >> testRemoveColumnAt [
 ]
 
 { #category : #tests }
+DataFrameInternalTest >> testRemoveColumnsOfRowElementsSatisfingOnRow [
+
+	| expected |
+	
+	df := DataFrameInternal withRows: #(
+		('Barcelona' 1.609 nil)
+   		('Dubai' 2.789 true)
+   		('London' nil nil)
+		('Washington' nil true)
+		('Delhi' 10.422 nil)).
+	
+	expected := DataFrameInternal withRows: #(
+		('Barcelona')
+   		('Dubai')
+   		('London')
+		('Washington')
+		('Delhi')).
+	
+	self assert: (df removeColumnsOfRowElementsSatisfing: [ :ele | ele isNil ] onRow: 3) equals: expected.
+]
+
+{ #category : #tests }
 DataFrameInternalTest >> testRemoveRowAt [
 
 	| expected |
@@ -315,6 +337,25 @@ DataFrameInternalTest >> testRemoveRowAt [
 	self assert: df equals: expected.
 	
 
+]
+
+{ #category : #tests }
+DataFrameInternalTest >> testRemoveRowsOfColumnElementsSatisfingOnColumn [
+
+	| expected |
+	
+	df := DataFrameInternal withRows: #(
+		('Barcelona' 1.609 nil)
+   		('Dubai' 2.789 true)
+   		('London' 8.788 nil)
+		('Washington' nil true)
+		('Delhi' 10.422 nil)).
+	
+	expected := DataFrameInternal withRows: #(
+   		('Dubai' 2.789 true)
+		('Washington' nil true)).
+	
+	self assert: (df removeRowsOfColumnElementsSatisfing: [ :ele | ele isNil ] onColumn: 3) equals: expected.
 ]
 
 { #category : #tests }

--- a/src/DataFrame-Tests/DataFrameTest.class.st
+++ b/src/DataFrame-Tests/DataFrameTest.class.st
@@ -1539,6 +1539,118 @@ DataFrameTest >> testRemoveColumnNotFound [
 ]
 
 { #category : #tests }
+DataFrameTest >> testRemoveColumnsOfRowElementsSatisfingOnRow [
+
+	| expected aBlock |
+	df := DataFrame withRows: #(
+		(1 2 3)
+   		(Dubai 4 5.0)
+   		(nil 8.788 false)).
+		
+	df rowNames: #(A B C).
+	df columnNames: #(X Y Z).
+	
+	expected := DataFrame withRows: #(
+		(2)
+   		(4)
+   		(8.788)).
+		
+	expected rowNames: #(A B C).
+	expected columnNames: #(Y).
+	
+	aBlock := [ :rowElement | rowElement ~= 4 ].
+	
+	self assert: (df removeColumnsOfRowElementsSatisfing: aBlock onRow: 2) equals: expected.
+]
+
+{ #category : #tests }
+DataFrameTest >> testRemoveColumnsOfRowElementsSatisfingOnRowAllTrue [
+
+	| expected aBlock |
+	
+	expected := DataFrame withRows: #().
+	aBlock := [ :rowElement | true ].
+	
+	self assert: (df removeColumnsOfRowElementsSatisfing: aBlock onRow: 2) equals: expected.
+]
+
+{ #category : #tests }
+DataFrameTest >> testRemoveColumnsOfRowElementsSatisfingOnRowNamed [
+
+	| expected aBlock |
+	df := DataFrame withRows: #(
+		(1 2 3)
+   		(Dubai 4 5.0)
+   		(nil 8.788 false)).
+		
+	df rowNames: #(A B C).
+	df columnNames: #(X Y Z).
+	
+	expected := DataFrame withRows: #(
+		(2)
+   		(4)
+   		(8.788)).
+		
+	expected rowNames: #(A B C).
+	expected columnNames: #(Y).
+	
+	aBlock := [ :rowElement | rowElement ~= 4 ].
+	
+	self assert: (df removeColumnsOfRowElementsSatisfing: aBlock onRowNamed: 'B') equals: expected.
+]
+
+{ #category : #tests }
+DataFrameTest >> testRemoveColumnsWithNilsAtRow [
+
+	| expected |
+	df := DataFrame withRows: #(
+		(Barcelona 1.609 nil)
+   		(Dubai nil nil)
+   		(nil 8.788 false)).
+		
+	df rowNames: #(A B C).
+	df columnNames: #(City Population BeenThere).
+	
+	expected := DataFrame withRows: #(
+		(Barcelona)
+   		(Dubai)
+   		(nil)).
+		
+	expected rowNames: #(A B C).
+	expected columnNames: #(City).
+	
+	self assert: (df removeColumnsWithNilsAtRow: 2) equals: expected.
+]
+
+{ #category : #tests }
+DataFrameTest >> testRemoveColumnsWithNilsAtRowNamed [
+
+	| expected |
+	df := DataFrame withRows: #(
+		(Barcelona 1.609 nil)
+   		(Dubai nil nil)
+   		(nil 8.788 false)).
+		
+	df rowNames: #(A B C).
+	df columnNames: #(City Population BeenThere).
+	
+	expected := DataFrame withRows: #(
+		(Barcelona)
+   		(Dubai)
+   		(nil)).
+		
+	expected rowNames: #(A B C).
+	expected columnNames: #(City).
+	
+	self assert: (df removeColumnsWithNilsAtRowNamed: #B) equals: expected.
+]
+
+{ #category : #tests }
+DataFrameTest >> testRemoveColumnsWithNilsAtRowOutOfRange [
+	self should: [ df removeColumnsWithNilsAtRow: 100 ] raise: SubscriptOutOfBounds.
+]
+
+{ #category : #tests }
 DataFrameTest >> testRemoveRow [
 
 	| expected |
@@ -1580,6 +1692,110 @@ DataFrameTest >> testRemoveRowAtOutOfRange [
 { #category : #tests }
 DataFrameTest >> testRemoveRowNotFound [
 	self should: [ df removeRow: #NoSuchRow ] raise: NotFoundError.
+]
+
+{ #category : #tests }
+DataFrameTest >> testRemoveRowsOfColumnElementsSatisfingOnColumn [
+
+	| expected aBlock |
+	df := DataFrame withRows: #(
+		(1 2 3)
+   		(Dubai 4 5.0)
+   		(nil 8.788 false)).
+		
+	df rowNames: #(A B C).
+	df columnNames: #(X Y Z).
+	
+	expected := DataFrame withRows: #(
+		(Dubai 4 5.0)).
+		
+	expected rowNames: #(B).
+	expected columnNames: #(X Y Z).
+	
+	aBlock := [ :rowElement | rowElement ~= 4 ].
+	
+	self assert: (df removeRowsOfColumnElementsSatisfing: aBlock onColumn: 2) equals: expected.
+]
+
+{ #category : #tests }
+DataFrameTest >> testRemoveRowsOfColumnElementsSatisfingOnColumnAllTrue [
+
+	| expected aBlock |
+	
+	expected := DataFrame withColumns: #().	
+	aBlock := [ :rowElement | true ].
+	
+	self assert: (df removeRowsOfColumnElementsSatisfing: aBlock onColumn: 2) equals: expected.
+]
+
+{ #category : #tests }
+DataFrameTest >> testRemoveRowsOfColumnElementsSatisfingOnColumnNamed [
+
+	| expected aBlock |
+	df := DataFrame withRows: #(
+		(1 2 3)
+   		(Dubai 4 5.0)
+   		(nil 8.788 false)).
+		
+	df rowNames: #(A B C).
+	df columnNames: #(X Y Z).
+	
+	expected := DataFrame withRows: #(
+		(Dubai 4 5.0)).
+		
+	expected rowNames: #(B).
+	expected columnNames: #(X Y Z).
+	
+	aBlock := [ :rowElement | rowElement ~= 4 ].
+	
+	self assert: (df removeRowsOfColumnElementsSatisfing: aBlock onColumnNamed: #Y) equals: expected.
+]
+
+{ #category : #tests }
+DataFrameTest >> testRemoveRowsWithNilsAtColumn [
+
+	| expected |
+	df := DataFrame withRows: #(
+		(Barcelona 1.609 nil)
+   		(Dubai nil nil)
+   		(nil 8.788 false)).
+		
+	df rowNames: #(A B C).
+	df columnNames: #(City Population BeenThere).
+	
+	expected := DataFrame withRows: #(
+   		(nil 8.788 false)).
+		
+	expected rowNames: #(C).
+	expected columnNames: #(City Population BeenThere).
+	
+	self assert: (df removeRowsWithNilsAtColumn: 3) equals: expected.
+]
+
+{ #category : #tests }
+DataFrameTest >> testRemoveRowsWithNilsAtColumnNamed [
+
+	| expected |
+	df := DataFrame withRows: #(
+		(Barcelona 1.609 nil)
+   		(Dubai nil nil)
+   		(nil 8.788 false)).
+		
+	df rowNames: #(A B C).
+	df columnNames: #(City Population BeenThere).
+	
+	expected := DataFrame withRows: #(
+   		(nil 8.788 false)).
+		
+	expected rowNames: #(C).
+	expected columnNames: #(City Population BeenThere).
+	
+	self assert: (df removeRowsWithNilsAtColumnNamed: #BeenThere) equals: expected.
+]
+
+{ #category : #tests }
+DataFrameTest >> testRemoveRowsWithNilsAtColumnOutOfRange [
+	self should: [ df removeRowsWithNilsAtColumn: 100 ] raise: SubscriptOutOfBounds.
 ]
 
 { #category : #tests }

--- a/src/DataFrame-Tests/DataSeriesTest.class.st
+++ b/src/DataFrame-Tests/DataSeriesTest.class.st
@@ -1426,6 +1426,28 @@ DataSeriesTest >> testRemoveAtIndex [
 	self assert: series equals: expected.
 ]
 
+{ #category : #removing }
+DataSeriesTest >> testRemoveNils [
+
+	| expected |
+	
+	series := DataSeries withKeys: #(1 2 'a' 3) values: #(nil 4.2 'b' nil).
+	expected := DataSeries withKeys: #(2 'a') values: #(4.2 'b').
+	
+	self assert: series removeNils equals: expected.
+]
+
+{ #category : #removing }
+DataSeriesTest >> testRemoveNilsOnNamedSeries [
+
+	| expected |
+	
+	series := DataSeries withKeys: #(1 2 'a' 3) values: #(nil 4.2 'b' nil) name: 'A'.
+	expected := DataSeries withKeys: #(2 'a') values: #(4.2 'b') name: 'A'.
+	
+	self assert: series removeNils equals: expected.
+]
+
 { #category : #accessing }
 DataSeriesTest >> testSecond [
 

--- a/src/DataFrame-Tests/DataSeriesTest.class.st
+++ b/src/DataFrame-Tests/DataSeriesTest.class.st
@@ -898,6 +898,27 @@ DataSeriesTest >> testCollect [
 	self assert: actual equals: expected.
 ]
 
+{ #category : #enumerating }
+DataSeriesTest >> testCollectWithNotNils [
+
+	| actual expected |
+
+	series := DataSeries
+		withKeys: #(a b c d e f g h i j k)
+		values: #(nil 7 6 nil 8 9 8 10 nil 13 16)
+		name: 'ExampleSeries'.
+	
+	actual := series collectWithNotNils: [ :each |
+		each / 10 ].
+	
+	expected := DataSeries
+		withKeys: keyArray
+		values: { nil . 7/10 . 3/5 . nil . 4/5 . 9/10 . 4/5 . 1 . nil . 13/10 . 8/5 }
+		name: 'ExampleSeries'.
+	
+	self assert: actual equals: expected.
+]
+
 { #category : #copying }
 DataSeriesTest >> testCopyCanBeChanged [
 

--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -951,6 +951,41 @@ DataFrame >> removeColumnAt: columnNumber [
 ]
 
 { #category : #removing }
+DataFrame >> removeColumnsOfRowElementsSatisfing: aBlock onRow: rowNumber [
+
+	| columnNamesCopy |
+	(rowNumber < 1 or: [ rowNumber > self numberOfRows ])
+		ifTrue: [ SubscriptOutOfBounds signalFor: rowNumber ].
+		
+	columnNamesCopy := columnNames deepCopy.
+	columnNames removeAll.
+	columnNamesCopy withIndexDo: [ :columnName :j |
+		(aBlock value: (contents at: rowNumber at: j))
+			ifFalse: [ columnNames add: columnName ]].
+	contents removeColumnsOfRowElementsSatisfing: aBlock onRow: rowNumber.
+	
+	self numberOfColumns = 0 ifTrue: [ rowNames removeAll ].
+]
+
+{ #category : #removing }
+DataFrame >> removeColumnsOfRowElementsSatisfing: aBlock onRowNamed: rowName [
+
+	| index |
+	index := self indexOfRowNamed: rowName.
+	self removeColumnsOfRowElementsSatisfing: aBlock onRow: index.
+]
+
+{ #category : #removing }
+DataFrame >> removeColumnsWithNilsAtRow: rowNumber [
+	self removeColumnsOfRowElementsSatisfing: [ :ele | ele isNil ] onRow: rowNumber.
+]
+
+{ #category : #removing }
+DataFrame >> removeColumnsWithNilsAtRowNamed: rowName [
+	self removeColumnsOfRowElementsSatisfing: [ :ele | ele isNil ] onRowNamed: rowName.
+]
+
+{ #category : #removing }
 DataFrame >> removeRow: rowName [
 
 	| index |
@@ -965,6 +1000,41 @@ DataFrame >> removeRowAt: rowNumber [
 		
 	contents removeRowAt: rowNumber.
 	rowNames := rowNames copyWithoutIndex: rowNumber.
+]
+
+{ #category : #removing }
+DataFrame >> removeRowsOfColumnElementsSatisfing: aBlock onColumn: columnNumber [
+	
+	| rowNamesCopy |
+	(columnNumber < 1 or: [ columnNumber > self numberOfColumns ])
+		ifTrue: [ SubscriptOutOfBounds signalFor: columnNumber ].
+
+	rowNamesCopy := rowNames deepCopy.
+	rowNames removeAll.
+	rowNamesCopy withIndexDo: [ :rowName :i |
+		(aBlock value: (contents at: i at: columnNumber))
+			ifFalse: [ rowNames add: rowName ] ].
+	contents removeRowsOfColumnElementsSatisfing: aBlock onColumn: columnNumber.
+	
+	self numberOfRows = 0 ifTrue: [ columnNames removeAll ].
+]
+
+{ #category : #removing }
+DataFrame >> removeRowsOfColumnElementsSatisfing: aBlock onColumnNamed: columnName [
+
+	| index |
+	index := self indexOfColumnNamed: columnName.
+	self removeRowsOfColumnElementsSatisfing: aBlock onColumn: index.
+]
+
+{ #category : #removing }
+DataFrame >> removeRowsWithNilsAtColumn: columnNumber [
+	self removeRowsOfColumnElementsSatisfing: [ :ele | ele isNil ] onColumn: columnNumber.
+]
+
+{ #category : #removing }
+DataFrame >> removeRowsWithNilsAtColumnNamed: columnName [
+	self removeRowsOfColumnElementsSatisfing: [ :ele | ele isNil ] onColumnNamed: columnName.
 ]
 
 { #category : #renaming }

--- a/src/DataFrame/DataFrameInternal.class.st
+++ b/src/DataFrame/DataFrameInternal.class.st
@@ -301,6 +301,37 @@ DataFrameInternal >> removeColumnAt: columnNumber [
 ]
 
 { #category : #removing }
+DataFrameInternal >> removeColumnsOfRowElementsSatisfing: aBlock onRow: rowNumber [
+	"Executes aBlock for all elements in specified rowNumber and deletes the column
+	 which satisfied condition given in aBlock."
+
+	| newContents columnsToDrop k |
+	"columnsToDrop has 1 at i if i-th column needs to be dropped, else 0"
+	columnsToDrop := (self rowAt: rowNumber) collect: [ :ele |
+		(aBlock value: ele) ifTrue: [ true ] ifFalse: [ false ] ].
+	
+	newContents := Array2D
+		rows: (self numberOfRows)
+		columns: (self numberOfColumns - (columnsToDrop select: [ :ele | ele ]) size).
+	
+	(newContents numberOfColumns = 0) ifTrue: [ 
+		contents := Array2D rows: 0 columns: 0.
+		^ self.
+		].
+		
+	1 to: self numberOfRows do: [ :i |
+		k := 0.
+		1 to: self numberOfColumns do: [ :j |
+			(columnsToDrop at: j)
+				ifTrue: [ k := k + 1 ]
+				ifFalse: [
+				newContents at: i at: j - k put:
+					(contents at: i at: j) ]]].
+		
+	contents := newContents.
+]
+
+{ #category : #removing }
 DataFrameInternal >> removeRowAt: rowNumber [
 
 	| newContents |
@@ -316,6 +347,35 @@ DataFrameInternal >> removeRowAt: rowNumber [
 		rowNumber + 1 to: self numberOfRows do: [ :i |
 			newContents at: i - 1 at: j put:
 				(contents at: i at: j) ] ].
+		
+	contents := newContents.
+]
+
+{ #category : #removing }
+DataFrameInternal >> removeRowsOfColumnElementsSatisfing: aBlock onColumn: columnNumber [
+	"Removes all rows having a nil value at the column columnNumber"
+
+	| newContents rowsToDrop k |
+	"rowsToDrop has 1 at i if i-th row needs to be dropped, else 0"
+	rowsToDrop := (self columnAt: columnNumber) collect: [ :ele |
+		(aBlock value: ele) ifTrue: [ true ] ifFalse: [ false ] ].
+	newContents := Array2D
+		rows: (self numberOfRows - (rowsToDrop select: [ :ele | ele ]) size)
+		columns: (self numberOfColumns).
+		
+	(newContents numberOfRows = 0) ifTrue: [ 
+		contents := Array2D rows: 0 columns: 0.
+		^ self.
+		].
+	
+	1 to: self numberOfColumns do: [ :j |
+		k := 0.
+		1 to: self numberOfRows do: [ :i |
+			(rowsToDrop at: i)
+				ifTrue: [ k := k + 1 ]
+				ifFalse: [
+				newContents at: i - k at: j put:
+					(contents at: i at: j) ]]].
 		
 	contents := newContents.
 ]

--- a/src/DataFrame/DataSeries.class.st
+++ b/src/DataFrame/DataSeries.class.st
@@ -396,6 +396,11 @@ DataSeries >> removeAtIndex: aNumber [
 	^ self removeAt: (self keys at: aNumber)
 ]
 
+{ #category : #removing }
+DataSeries >> removeNils [
+	^ self reject: [ :ele | ele isNil ]
+]
+
 { #category : #accessing }
 DataSeries >> second [
 	"Answer the second element of the receiver.

--- a/src/DataFrame/DataSeries.class.st
+++ b/src/DataFrame/DataSeries.class.st
@@ -175,6 +175,14 @@ DataSeries >> collect: aBlock [
 	^ result
 ]
 
+{ #category : #enumerating }
+DataSeries >> collectWithNotNils: aBlock [
+	"Applies aBlock to every non-nil element"
+	^ self collect: [ :each |
+		each isNil ifTrue: [ nil ] ifFalse: [ aBlock value: each ]
+		]
+]
+
 { #category : #statistics }
 DataSeries >> crossTabulateWith: aSeries [
 	| df |


### PR DESCRIPTION
DataSeries can remove nils using the method `removeNils`
DataFrame can remove nils from rows and columns using methods:
- `removeColumnsWithNilsAtRow:`
- `removeColumnsWithNilsAtRowNamed:`
- `removeRowsWithNilsAtColumn:`
- `removeRowsWithNilsAtColumnNamed:`
Added relevant tests for these methods