### PR TITLE
Json support

### DIFF
--- a/src/BaselineOfDataFrame/BaselineOfDataFrame.class.st
+++ b/src/BaselineOfDataFrame/BaselineOfDataFrame.class.st
@@ -35,6 +35,9 @@ BaselineOfDataFrame >> baseline: spec [
 		spec
 			baseline: 'NeoCSV'
 			with: [ spec repository: 'github://svenvc/NeoCSV/repository' ].
+		spec
+			baseline: 'NeoJSON'
+			with: [ spec repository: 'github://svenvc/NeoJSON/repository' ].
 				
 		"Packages"
 		spec 
@@ -42,7 +45,7 @@ BaselineOfDataFrame >> baseline: spec [
 			package: 'DataFrame-Tests' with: [ spec requires: #('DataFrame') ];
 			package: 'DataFrame-Type' with: [ spec requires: #('DataFrame') ];
 			package: 'DataFrame-Type-Tests' with: [ spec requires: #('DataFrame-Type') ];
-			package: 'DataFrame-IO' with: [ spec requires: #('DataFrame' 'DataFrame-Type' 'NeoCSV') ];
+			package: 'DataFrame-IO' with: [ spec requires: #('DataFrame' 'DataFrame-Type' 'NeoCSV' 'NeoJSON') ];
 			package: 'DataFrame-IO-Tests' with: [ spec requires: #('DataFrame-IO') ]].
 		
 		spec

--- a/src/DataFrame-IO-Tests/DataFrameJsonReaderTest.class.st
+++ b/src/DataFrame-IO-Tests/DataFrameJsonReaderTest.class.st
@@ -1,0 +1,148 @@
+Class {
+	#name : #DataFrameJsonReaderTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'directory',
+		'df',
+		'dfWithColNames',
+		'dfWithRowNames',
+		'dfWithRowColNames'
+	],
+	#category : #'DataFrame-IO-Tests'
+}
+
+{ #category : #running }
+DataFrameJsonReaderTest >> createFileNamed: name withContents: aString [
+	| stream |
+	stream := (directory / name) writeStream.
+	stream nextPutAll: aString.
+	stream close.
+]
+
+{ #category : #running }
+DataFrameJsonReaderTest >> setUp [
+	super setUp.
+	directory := FileSystem memory workingDirectory / 'testDataForJson'.
+	directory createDirectory.
+	
+	self createFileNamed: 'column.json' withContents: TestJsonStrings columnJsonString.
+	self createFileNamed: 'index.json' withContents: TestJsonStrings indexJsonString.
+	self createFileNamed: 'nonNull1.json' withContents: TestJsonStrings nonNullJsonString1.
+	self createFileNamed: 'records.json' withContents: TestJsonStrings recordsJsonString.
+	self createFileNamed: 'split.json' withContents: TestJsonStrings splitJsonString.
+	self createFileNamed: 'values.json' withContents: TestJsonStrings valuesJsonString.
+	
+	df := DataFrame withRows: #(
+		(1 2 nil nil)
+		(nil 2 3 nil)
+		(nil nil nil 5)
+		(1 nil 2 nil)).
+	
+	dfWithColNames := df deepCopy.
+	dfWithColNames columnNames: #('col1' 'col2' 'col3' 'col4').
+	
+	dfWithRowNames := df deepCopy.
+	dfWithRowNames rowNames: #('row1' 'row2' 'row3' 'row4').
+	
+	dfWithRowColNames := df deepCopy.
+	dfWithRowColNames columnNames: #('col1' 'col2' 'col3' 'col4').
+	dfWithRowColNames rowNames: #('row1' 'row2' 'row3' 'row4').
+	
+	
+	
+
+]
+
+{ #category : #running }
+DataFrameJsonReaderTest >> sortByRowColNames: inputDf [
+	"Sorts df according to column and row names"
+	
+	| sortedRowNames sortedColNames dfColSorted outputDf |
+	sortedRowNames := inputDf rowNames sorted.
+	sortedColNames := inputDf columnNames sorted.
+	
+	dfColSorted := DataFrame withRowNames: inputDf rowNames.
+	sortedColNames do: [ :col | dfColSorted addColumn: (inputDf column: col) asArray named: col ].
+	
+	outputDf := DataFrame withColumnNames: dfColSorted columnNames.
+	sortedRowNames do: [ :row | outputDf addRow: (dfColSorted row: row) asArray named: row ].
+	
+	^ outputDf
+]
+
+{ #category : #tests }
+DataFrameJsonReaderTest >> testReadFrom [
+	| output |
+
+	output := DataFrameJsonReader new readFrom: directory / 'nonNull1.json'.
+	
+	self assert: (self sortByRowColNames: output) equals: dfWithColNames.
+]
+
+{ #category : #tests }
+DataFrameJsonReaderTest >> testReadFromColumns [
+	| output |
+
+	output := DataFrameJsonReader new readFrom: directory / 'column.json'.
+	
+	self assert: (self sortByRowColNames: output) equals: dfWithRowColNames.
+]
+
+{ #category : #tests }
+DataFrameJsonReaderTest >> testReadFromIndex [
+	| output |
+
+	output := DataFrameJsonReader new readFrom: directory / 'index.json'.
+	
+	self assert: (self sortByRowColNames: output) equals: dfWithRowColNames transposed.
+]
+
+{ #category : #tests }
+DataFrameJsonReaderTest >> testReadFromJson [
+	| output |
+	output := DataFrame readFromJson: (directory / 'nonNull1.json').
+	self assert: (self sortByRowColNames: output) equals: dfWithColNames.
+]
+
+{ #category : #tests }
+DataFrameJsonReaderTest >> testReadFromJsonOrient [
+	| output |
+	output := DataFrame readFromJson: (directory / 'split.json') orient: 'split'.
+	self assert: (self sortByRowColNames: output) equals: dfWithRowColNames.
+]
+
+{ #category : #tests }
+DataFrameJsonReaderTest >> testReadFromRecords [
+	| output |
+
+	output := DataFrameJsonReader new readFrom: directory / 'records.json'.
+	
+	self assert: (self sortByRowColNames: output) equals: dfWithColNames.
+]
+
+{ #category : #tests }
+DataFrameJsonReaderTest >> testReadFromSplit [
+	| output |
+
+	output := DataFrameJsonReader new readFrom: directory / 'split.json'.
+	
+	self assert: (self sortByRowColNames: output) equals: dfWithRowColNames.
+]
+
+{ #category : #tests }
+DataFrameJsonReaderTest >> testReadFromString [
+	| output |
+
+	output := DataFrameJsonReader new readFrom: TestJsonStrings nonNullJsonString2.
+	
+	self assert: (self sortByRowColNames: output) equals: dfWithRowColNames.
+]
+
+{ #category : #tests }
+DataFrameJsonReaderTest >> testReadFromValues [
+	| output |
+
+	output := DataFrameJsonReader new readFrom: directory / 'values.json'.
+	
+	self assert: (self sortByRowColNames: output) equals: df.
+]

--- a/src/DataFrame-IO-Tests/DataFrameJsonWriterTest.class.st
+++ b/src/DataFrame-IO-Tests/DataFrameJsonWriterTest.class.st
@@ -1,0 +1,75 @@
+Class {
+	#name : #DataFrameJsonWriterTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'directory',
+		'df'
+	],
+	#category : #'DataFrame-IO-Tests'
+}
+
+{ #category : #running }
+DataFrameJsonWriterTest >> readFile: aFileReference [
+	| stream contents |
+	stream := aFileReference readStream.
+	contents := stream upToEnd.
+	stream close.
+	^ contents
+]
+
+{ #category : #running }
+DataFrameJsonWriterTest >> setUp [
+	super setUp.
+	directory := FileSystem memory workingDirectory / 'testDataForJson'.
+	directory createDirectory.
+	
+	df := DataFrame withRows: #(
+		(1 2 nil nil)
+		(nil 2 3 nil)
+		(nil nil nil 5)
+		(1 nil 2 nil))
+	rowNames: #('row1' 'row2' 'row3' 'row4')
+	columnNames: #('col1' 'col2' 'col3' 'col4').
+]
+
+{ #category : #tests }
+DataFrameJsonWriterTest >> testWriteAsString [
+	| actual expected |.
+	actual := DataFrameJsonWriter new writeAsString: df.
+	expected := '' join: (TestJsonStrings recordsJsonString 
+		regex: '[^\s]+' matchesCollect: [:x|x]).
+	self assert: actual equals: expected.
+]
+
+{ #category : #tests }
+DataFrameJsonWriterTest >> testWriteTo [
+	| file actual expected |
+	file := directory / 'output.json'.
+	DataFrameJsonWriter new write: df to: file.
+	actual := self readFile: file.
+	expected := '' join: (TestJsonStrings recordsJsonString 
+		regex: '[^\s]+' matchesCollect: [:x|x]).
+	self assert: actual lines equals: expected lines.
+]
+
+{ #category : #tests }
+DataFrameJsonWriterTest >> testWriteToJson [
+	| file actual expected |
+	file := directory / 'output.json'.
+	df writeToJson: file.
+	actual := self readFile: file.
+	expected := '' join: (TestJsonStrings recordsJsonString 
+		regex: '[^\s]+' matchesCollect: [:x|x]).
+	self assert: actual lines equals: expected lines.
+]
+
+{ #category : #tests }
+DataFrameJsonWriterTest >> testWriteToJsonOrient [
+	| file actual expected |
+	file := directory / 'output.json'.
+	df writeToJson: file orient: 'values'.
+	actual := self readFile: file.
+	expected := '' join: (TestJsonStrings valuesJsonString 
+		regex: '[^\s]+' matchesCollect: [:x|x]).
+	self assert: actual lines equals: expected lines.
+]

--- a/src/DataFrame-IO-Tests/TestJsonStrings.class.st
+++ b/src/DataFrame-IO-Tests/TestJsonStrings.class.st
@@ -1,0 +1,60 @@
+Class {
+	#name : #TestJsonStrings,
+	#superclass : #Object,
+	#category : #'DataFrame-IO-Tests'
+}
+
+{ #category : #running }
+TestJsonStrings class >> columnJsonString [
+	^ '{"col1":{"row1":1.0,"row2":null,"row3":null,"row4":1.0},
+"col2":{"row1":2.0,"row2":2.0,"row3":null,"row4":null},
+"col3":{"row1":null,"row2":3.0,"row3":null,"row4":2.0},
+"col4":{"row1":null,"row2":null,"row3":5.0,"row4":null}}'
+]
+
+{ #category : #running }
+TestJsonStrings class >> indexJsonString [
+	^ '{"row1":{"col1":1.0,"col2":2.0,"col3":null,"col4":null},
+"row2":{"col1":null,"col2":2.0,"col3":3.0,"col4":null},
+"row3":{"col1":null,"col2":null,"col3":null,"col4":5.0},
+"row4":{"col1":1.0,"col2":null,"col3":2.0,"col4":null}}'
+]
+
+{ #category : #running }
+TestJsonStrings class >> nonNullJsonString1 [
+	^ '[{"col1":1, "col2":2},
+		 {"col3":3, "col2":2},
+		 {"col4":5},
+		 {"col1":1, "col3":2}]'
+]
+
+{ #category : #running }
+TestJsonStrings class >> nonNullJsonString2 [
+	^ '{
+			"col1": {"row1":1, "row4":1},
+			"col2": {"row1":2, "row2":2},
+			"col3": {"row2":3, "row4":2},
+			"col4": {"row3":5}
+		}'
+]
+
+{ #category : #running }
+TestJsonStrings class >> recordsJsonString [
+	^ '[{"col1":1,"col2":2,"col3":null,"col4":null},
+{"col1":null,"col2":2,"col3":3,"col4":null},
+{"col1":null,"col2":null,"col3":null,"col4":5},
+{"col1":1,"col2":null,"col3":2,"col4":null}]'
+]
+
+{ #category : #running }
+TestJsonStrings class >> splitJsonString [
+	^ '{"columns":["col1","col2","col3","col4"],
+"index":["row1","row2","row3","row4"],
+"data":[[1.0,2.0,null,null],[null,2.0,3.0,null],[null,null,null,5.0],[1.0,null,2.0,null]]}'
+]
+
+{ #category : #running }
+TestJsonStrings class >> valuesJsonString [
+	^ '[[1,2,null,null],[null,2,3,null],
+[null,null,null,5],[1,null,2,null]]'
+]

--- a/src/DataFrame-IO/DataFrame.extension.st
+++ b/src/DataFrame-IO/DataFrame.extension.st
@@ -84,3 +84,18 @@ DataFrame >> writeToCsv: aFileReference withSeparator: aSeparator [
 	writer separator: aSeparator.
 	self writeTo: aFileReference using: writer.
 ]
+
+{ #category : #'*DataFrame-IO' }
+DataFrame >> writeToJson: aFileReference [
+	| writer |
+	writer := DataFrameJsonWriter new.
+	self writeTo: aFileReference using: writer.
+]
+
+{ #category : #'*DataFrame-IO' }
+DataFrame >> writeToJson: aFileReference orient: orient [
+	| writer |
+	writer := DataFrameJsonWriter new.
+	writer orient: orient.
+	self writeTo: aFileReference using: writer.
+]

--- a/src/DataFrame-IO/DataFrame.extension.st
+++ b/src/DataFrame-IO/DataFrame.extension.st
@@ -99,3 +99,20 @@ DataFrame >> writeToJson: aFileReference orient: orient [
 	writer orient: orient.
 	self writeTo: aFileReference using: writer.
 ]
+
+{ #category : #'*DataFrame-IO' }
+DataFrame >> writeToPrettyJson: aFileReference [
+	| writer |
+	writer := DataFrameJsonWriter new.
+	writer pretty: true.
+	self writeTo: aFileReference using: writer.
+]
+
+{ #category : #'*DataFrame-IO' }
+DataFrame >> writeToPrettyJson: aFileReference orient: orient [
+	| writer |
+	writer := DataFrameJsonWriter new.
+	writer orient: orient.
+	writer pretty: true.
+	self writeTo: aFileReference using: writer.
+]

--- a/src/DataFrame-IO/DataFrame.extension.st
+++ b/src/DataFrame-IO/DataFrame.extension.st
@@ -50,6 +50,21 @@ DataFrame class >> readFromCsvWithRowNames: aFileReference separator: aSeparator
 ]
 
 { #category : #'*DataFrame-IO' }
+DataFrame class >> readFromJson: aFileReference [ 
+	| reader |
+	reader := DataFrameJsonReader new.
+	^ self readFrom: aFileReference using: reader.
+]
+
+{ #category : #'*DataFrame-IO' }
+DataFrame class >> readFromJson: aFileReference orient: orient [
+	| reader |
+	reader := DataFrameJsonReader new.
+	reader orient: orient.
+	^ self readFrom: aFileReference using: reader.
+]
+
+{ #category : #'*DataFrame-IO' }
 DataFrame >> writeTo: aLocation using: aDataFrameWriter [
 	"Write data frame to a given location using a given DataFrameWriter. Location can be a file reference, a database connection, or something else (depending on the implementation of the writer)"
 	aDataFrameWriter write: self to: aLocation

--- a/src/DataFrame-IO/DataFrameJsonReader.class.st
+++ b/src/DataFrame-IO/DataFrameJsonReader.class.st
@@ -1,0 +1,228 @@
+Class {
+	#name : #DataFrameJsonReader,
+	#superclass : #DataFrameReader,
+	#instVars : [
+		'rowNames',
+		'rows',
+		'columnNames',
+		'orient',
+		'uniform',
+		'parseMap'
+	],
+	#category : #'DataFrame-IO'
+}
+
+{ #category : #adding }
+DataFrameJsonReader >> addDict: aDict [
+	"Adds aDict while respecting columnNames positions"
+	
+	| newCols |
+	
+	newCols := aDict keys difference: columnNames.
+	columnNames addAll: newCols.
+	
+	rows add: (columnNames collect: [ :col | aDict at: col ifAbsent: nil ]).
+]
+
+{ #category : #reading }
+DataFrameJsonReader >> createDataFrame [
+	| df |
+	
+	df := DataFrame withRows: rows.
+	rowNames ifNotNil: [ df rowNames: rowNames ].
+	columnNames ifNotNil: [ df columnNames: columnNames  ].
+	
+	^ df
+]
+
+{ #category : #'initialization - private' }
+DataFrameJsonReader >> inferOrientFromJson: json [
+	"Inferes the json type (orient parameter). Runs when orient='auto'"
+
+	(json isKindOf: SequenceableCollection)
+		ifTrue: [
+			((json first) isKindOf: SequenceableCollection)
+				ifTrue: [ self orient: 'values' ]
+				ifFalse: [ self orient: 'records' ]
+			]
+		ifFalse: [
+			((json at: (json keys first)) isKindOf: SequenceableCollection)
+				ifTrue: [ self orient: 'split' ]
+				ifFalse: [ self orient: 'columns' ].
+			].
+]
+
+{ #category : #initialization }
+DataFrameJsonReader >> initialize [
+	super initialize.
+	orient := self orientDefaultValue.
+	uniform := self uniformDefaultValue.
+	parseMap := Dictionary newFrom: {
+		'records'->[ :json | self parseFromRecords: json ].
+		'columns'->[ :json | self parseFromColumns: json ].
+		'index'->[ :json | self parseFromRowNames: json ].
+		'values'->[ :json | self parseFromValues: json ].
+		'split'->[ :json | self parseFromSplit: json ].
+		}.
+]
+
+{ #category : #accessing }
+DataFrameJsonReader >> orient [
+	^ orient
+]
+
+{ #category : #accessing }
+DataFrameJsonReader >> orient: aString [
+	orient := aString
+]
+
+{ #category : #accessing }
+DataFrameJsonReader >> orientDefaultValue [
+	^ 'auto'
+]
+
+{ #category : #parsing }
+DataFrameJsonReader >> parseFromColumns: aDict [
+	"Private. Accessed when orient = 'columns'.
+	 Slower if uniform is set to false.
+	 Incoming json format is:
+		
+		{
+		 column->{
+					 rowName->data
+					}
+		}
+		
+	"
+	| colIndex rowIndex |
+
+	columnNames := OrderedCollection newFrom: aDict keys.
+	rowNames := OrderedCollection new.
+	rows := OrderedCollection new.
+	
+	aDict keysAndValuesDo: [ :col :rowNamesDict |
+		colIndex := columnNames indexOf: col.
+		rowNamesDict keysAndValuesDo: [ :rowName :val |
+			rowIndex := rowNames indexOf: rowName ifAbsent: [
+				rowNames add: rowName. rowNames size ].
+			"Basically `row at:rowIndex at:colIndex put:val`"
+			(rows at: rowIndex
+					ifAbsentPut: (OrderedCollection ofSize: columnNames size)
+					)	at: colIndex
+						ifAbsentPut: val.
+			].
+		].
+]
+
+{ #category : #parsing }
+DataFrameJsonReader >> parseFromRecords: anArray [
+	"Private. Accessed when orient = 'records'.
+	 Incoming json format is:
+		[
+			{column->data},
+		]
+	"
+	
+	rows := OrderedCollection new: anArray size.
+	columnNames := OrderedCollection new.
+	rowNames := nil.
+	
+	anArray do: [ :record |
+		self addDict: record
+		].
+]
+
+{ #category : #parsing }
+DataFrameJsonReader >> parseFromRowNames: aDict [
+	"Private. Accessed when orient = 'rowNames'.
+	 Slower if uniform is set to false.
+	 Incoming json format is:
+		{
+		 rowName->{
+					 column->data
+					}
+		}
+	"
+
+	columnNames := OrderedCollection new.
+	rowNames := OrderedCollection new: (aDict keys) size.
+	rows := OrderedCollection new: (aDict keys) size.
+	
+	aDict keysAndValuesDo: [ :rowName :rowNamesDict |
+		rowNames add: rowName.
+		self addDict: rowNamesDict.
+		].
+]
+
+{ #category : #parsing }
+DataFrameJsonReader >> parseFromSplit: aDict [
+	"Private. Accessed when orient = 'split'.
+	 Incoming json format is:
+		{
+			index->[rowNames],
+			columns->[columnNames],
+			data->[data]
+		}
+	"
+	
+	rows := aDict at: 'data'.
+	rowNames := aDict at: 'index'.
+	columnNames := aDict at: 'columns'.
+]
+
+{ #category : #parsing }
+DataFrameJsonReader >> parseFromValues: anArrayOfArrays [
+	"Private. Accessed when orient = 'values'"
+	
+	rows := anArrayOfArrays.
+]
+
+{ #category : #reading }
+DataFrameJsonReader >> read: json [
+	"Loads parsed json"
+	
+	json isEmpty
+		ifTrue: [ rows := #() ]
+		ifFalse: [
+			orient = 'auto' ifTrue: [ self inferOrientFromJson: json ].
+			(parseMap at: orient) value: json.
+			].
+]
+
+{ #category : #reading }
+DataFrameJsonReader >> readFrom: aFileReference [
+	| reader |
+	
+	reader := NeoJSONReader on: aFileReference readStream.
+	self read: reader next.
+	reader close.
+	
+	^ self createDataFrame
+	
+]
+
+{ #category : #reading }
+DataFrameJsonReader >> readFromString: aString [
+	"Read dataframe from a string"
+	| json |
+	
+	json := NeoJSONReader fromString: aString.
+	self read: json.
+	
+	^ self createDataFrame
+]
+
+{ #category : #accessing }
+DataFrameJsonReader >> uniform [
+	^ uniform
+]
+
+{ #category : #accessing }
+DataFrameJsonReader >> uniform: aBoolean [
+	uniform := aBoolean
+]
+
+{ #category : #accessing }
+DataFrameJsonReader >> uniformDefaultValue [
+	^ false
+]

--- a/src/DataFrame-IO/DataFrameJsonReader.class.st
+++ b/src/DataFrame-IO/DataFrameJsonReader.class.st
@@ -32,6 +32,8 @@ DataFrameJsonReader >> createDataFrame [
 	rowNames ifNotNil: [ df rowNames: rowNames ].
 	columnNames ifNotNil: [ df columnNames: columnNames  ].
 	
+	DataFrameTypeDetector new detectTypesAndConvert: df.
+	
 	^ df
 ]
 

--- a/src/DataFrame-IO/DataFrameJsonWriter.class.st
+++ b/src/DataFrame-IO/DataFrameJsonWriter.class.st
@@ -1,0 +1,175 @@
+Class {
+	#name : #DataFrameJsonWriter,
+	#superclass : #DataFrameWriter,
+	#instVars : [
+		'orient',
+		'pretty',
+		'writeMap'
+	],
+	#category : #'DataFrame-IO'
+}
+
+{ #category : #converting }
+DataFrameJsonWriter class >> convertToColumns: aDataFrame [
+	"Converts aDataFrame into following format:	
+		{
+		 column->{
+					 rowName->data
+					}
+		}
+		No need to actually convert, since dataframe gets iterated
+		in the above format itself.
+		Note: column is converted to string.
+	"
+	| output |
+	
+	output := Dictionary new.
+	aDataFrame asArrayOfColumns withIndexDo: [ :col :index |
+		output add: (aDataFrame columnNames at: index) asString -> col
+		].
+	^ output
+]
+
+{ #category : #converting }
+DataFrameJsonWriter class >> convertToRecords: aDataFrame [
+	"Converts aDataFrame into following format:
+		[
+			{column->data},
+		]
+		Note: It ignores rowNames
+		No need to actually convert, since dataframe gets iterated
+		in the above format itself.
+	"
+	
+	^ aDataFrame
+]
+
+{ #category : #converting }
+DataFrameJsonWriter class >> convertToRowNames: aDataFrame [
+	"Converts aDataFrame into following format:	
+		{
+		 rowName->{
+					 column->data
+					}
+		}
+		No need to actually convert, since dataframe gets iterated
+		in the above format itself.
+		Note: rowName is converted to string.
+	"
+	| output |
+	
+	output := Dictionary new.
+	aDataFrame asArrayOfRows withIndexDo: [ :row :index |
+		output add: (aDataFrame rowNames at: index) asString -> row
+		].
+	^ output
+]
+
+{ #category : #converting }
+DataFrameJsonWriter class >> convertToSplit: aDataFrame [
+	"Converts aDataFrame into following format:
+		{
+			index->[rowNames],
+			columns->[columnNames],
+			data->[data]
+		}
+		Note: It ignores rowNames
+		No need to actually convert, since dataframe gets iterated
+		in the above format itself.
+	"
+	| output rows |
+	
+	output := Dictionary new.
+	output add: 'index'->(aDataFrame rowNames).
+	output add: 'columns'->(aDataFrame columnNames).
+	
+	rows := OrderedCollection new: aDataFrame size.
+	aDataFrame do: [ :row | rows add: row asArray ].
+	
+	output add: 'data'->rows.
+	^ output
+]
+
+{ #category : #converting }
+DataFrameJsonWriter class >> convertToValues: aDataFrame [
+	"Converts aDataFrame into an array of arrays
+		Note: It ignores rowNames and columnNames
+		No need to actually convert, since dataframe gets iterated
+		in the above format itself.
+	"
+	| rows |
+	
+	rows := OrderedCollection new: aDataFrame size.
+	aDataFrame do: [ :row | rows add: row asArray ].
+	^ rows
+]
+
+{ #category : #accessing }
+DataFrameJsonWriter >> defaultOrient [
+	^ 'records'
+]
+
+{ #category : #accessing }
+DataFrameJsonWriter >> defaultPretty [
+	^ false
+]
+
+{ #category : #initialization }
+DataFrameJsonWriter >> initialize [
+	super initialize.
+	orient := self defaultOrient.
+	pretty := self defaultPretty.
+	writeMap := Dictionary newFrom: {
+		'records'->[ :aDataFrame :writeStream  | self class convertToRecords: aDataFrame].
+		'split'->[ :aDataFrame :writeStream    | self class convertToSplit: aDataFrame].
+		'columns'->[ :aDataFrame :writeStream  | self class convertToColumns: aDataFrame].
+		'rowNames'->[ :aDataFrame :writeStream | self class convertToRowNames: aDataFrame].
+		'values'->[ :aDataFrame :writeStream   | self class convertToValues: aDataFrame].
+		}.
+]
+
+{ #category : #accessing }
+DataFrameJsonWriter >> orient [
+	^ orient
+]
+
+{ #category : #accessing }
+DataFrameJsonWriter >> orient: aString [
+	orient := aString
+]
+
+{ #category : #accessing }
+DataFrameJsonWriter >> pretty [
+	^ pretty
+]
+
+{ #category : #accessing }
+DataFrameJsonWriter >> pretty: aBoolean [
+	pretty := aBoolean
+]
+
+{ #category : #writing }
+DataFrameJsonWriter >> write: aDataFrame to: aFileReference [
+	| writeStream writer jsonObj |
+	
+	writeStream := aFileReference writeStream.
+	writer := NeoJSONWriter new on: writeStream.
+	writer prettyPrint: pretty.
+	jsonObj := (writeMap at: orient) value: aDataFrame value: writeStream.
+	writer nextPut: jsonObj.
+	writer close.
+]
+
+{ #category : #writing }
+DataFrameJsonWriter >> writeAsString: aDataFrame [
+	"Returns JSON representation of aDataFrame according to orient"
+	| writeStream writer jsonObj |
+	
+	writeStream := WriteStream on: (String new: 100).
+	writer := NeoJSONWriter new on: writeStream.
+	writer prettyPrint: pretty.
+	jsonObj := (writeMap at: orient) value: aDataFrame value: writeStream.
+	writer nextPut: jsonObj.
+	writer close.
+	^ writeStream contents
+]


### PR DESCRIPTION
Fixes https://github.com/PolyMathOrg/DataFrame/issues/97.

There are 5 types of json to which you can read/write: `columns` `index` `values` `split` `records`.

The reader converts the json into appropriate types. When reading, the columns and rows do not maintain same order, due to structure of Dictionary (no inherent ordering). Sorting them is not done by default as it may be time consuming.