### PR TITLE
114-DataFramesize-is-very-slow-because-it-counts-by-DataFramedo

### DIFF
--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -1270,6 +1270,11 @@ DataFrame >> showWithGlamourIn: composite [
 	^ table
 ]
 
+{ #category : #accessing }
+DataFrame >> size [
+	^ self numberOfRows
+]
+
 { #category : #sorting }
 DataFrame >> sortBy: columnName [
 	self sortBy: columnName using: [ :a :b | a <= b ]


### PR DESCRIPTION
DataFrame>>size returns number of rows instead of counting by do: