### PR TITLE
122-DataFrame-classwithRowscolumnNames-fails-when-the-given-rows-are-empty

### DIFF
--- a/src/DataFrame-Tests/DataFrameTest.class.st
+++ b/src/DataFrame-Tests/DataFrameTest.class.st
@@ -4289,6 +4289,62 @@ DataFrameTest >> testVarSizeInstanceCreation [
 ]
 
 { #category : #tests }
+DataFrameTest >> testWithColumnsRowNames [
+	| dataframe |
+	dataframe := DataFrame
+		withColumns: #(#(1 2 3) #(4 5 6))
+		rowNames: #('one' 'two' 'three').
+	self
+		assert: dataframe rowNames asArray
+		equals: #('one' 'two' 'three').
+	self assert: (dataframe row: 'one') asArray equals: #(1 4).
+	self assert: (dataframe row: 'two') asArray equals: #(2 5).
+	self assert: (dataframe row: 'three') asArray equals: #(3 6)
+]
+
+{ #category : #tests }
+DataFrameTest >> testWithColumnsRowNamesColumnNames [
+	| dataframe |
+	dataframe := DataFrame
+		withColumns: #(#(1 4) #(2 5) #(3 6))
+		rowNames: #('1' '2')
+		columnNames: #('one' 'two' 'three').
+	self
+		assert: dataframe columnNames asArray
+		equals: #('one' 'two' 'three').
+	self assert: ((dataframe column: 'one') at: '1') equals: 1.
+	self assert: ((dataframe column: 'two') at: '1') equals: 2.
+	self assert: ((dataframe column: 'three') at: '1') equals: 3.
+	self assert: ((dataframe column: 'one') at: '2') equals: 4.
+	self assert: ((dataframe column: 'two') at: '2') equals: 5.
+	self assert: ((dataframe column: 'three') at: '2') equals: 6
+]
+
+{ #category : #tests }
+DataFrameTest >> testWithColumnsRowNamesColumnNames_emptyColumns [
+	| dataframe |
+	dataframe := DataFrame
+		withColumns: #()
+		rowNames: #('1' '2')
+		columnNames: #().
+	self assert: dataframe rowNames asArray equals: #('1' '2').
+	self assert: (dataframe row: '1') isEmpty.
+	self assert: (dataframe row: '2') isEmpty
+]
+
+{ #category : #tests }
+DataFrameTest >> testWithColumnsRowNames_emptyColumns [
+	| dataframe |
+	dataframe := DataFrame
+		withColumns: #()
+		rowNames: #('one' 'two' 'three').
+	self
+		assert: dataframe rowNames asArray
+		equals: #('one' 'two' 'three').
+	self assert: (dataframe row: 'one') isEmpty
+]
+
+{ #category : #tests }
 DataFrameTest >> testWithIndexCollect [
 	| expectedDf expectedResult actualResult |
 	
@@ -4386,4 +4442,61 @@ DataFrameTest >> testWithIndexSelect [
 		((row at: #Population) > 2) and: [ index % 2 = 0 ] ].
 	
 	self assert: actual equals: expected.
+]
+
+{ #category : #tests }
+DataFrameTest >> testWithRowsColumnNames [
+	| dataframe |
+	dataframe := DataFrame
+		withRows: #(#(1 2 3) #(4 5 6))
+		columnNames: #('one' 'two' 'three').
+	self
+		assert: dataframe columnNames asArray
+		equals: #('one' 'two' 'three').
+	self assert: (dataframe column: 'one') asArray equals: #(1 4).
+	self assert: (dataframe column: 'two') asArray equals: #(2 5).
+	self assert: (dataframe column: 'three') asArray equals: #(3 6)
+]
+
+{ #category : #tests }
+DataFrameTest >> testWithRowsColumnNames_emptyRows [
+	| dataframe |
+	dataframe := DataFrame
+		withRows: #()
+		columnNames: #('one' 'two' 'three').
+	self
+		assert: dataframe columnNames asArray
+		equals: #('one' 'two' 'three').
+	self assert: (dataframe column: 'one') isEmpty
+]
+
+{ #category : #tests }
+DataFrameTest >> testWithRowsRowNamesColumnNames [
+	| dataframe |
+	dataframe := DataFrame
+		withRows: #(#(1 2 3) #(4 5 6))
+		rowNames: #('1' '2')
+		columnNames: #('one' 'two' 'three').
+	self
+		assert: dataframe columnNames asArray
+		equals: #('one' 'two' 'three').
+	self assert: ((dataframe column: 'one') at: '1') equals: 1.
+	self assert: ((dataframe column: 'two') at: '1') equals: 2.
+	self assert: ((dataframe column: 'three') at: '1') equals: 3.
+	self assert: ((dataframe column: 'one') at: '2') equals: 4.
+	self assert: ((dataframe column: 'two') at: '2') equals: 5.
+	self assert: ((dataframe column: 'three') at: '2') equals: 6
+]
+
+{ #category : #tests }
+DataFrameTest >> testWithRowsRowNamesColumnNames_emptyRows [
+	| dataframe |
+	dataframe := DataFrame
+		withRows: #()
+		rowNames: #()
+		columnNames: #('one' 'two' 'three').
+	self
+		assert: dataframe columnNames asArray
+		equals: #('one' 'two' 'three').
+	self assert: (dataframe column: 'one') isEmpty
 ]

--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -199,21 +199,21 @@ DataFrame class >> withColumns: anArrayOfArrays columnNames: anArrayOfColumnName
 
 { #category : #'instance creation' }
 DataFrame class >> withColumns: anArrayOfArrays rowNames: anArrayOfRowNames [
-
-	| df |
-	df := self withColumns: anArrayOfArrays.
-	df rowNames: anArrayOfRowNames.
-	^ df
+	^ anArrayOfArrays
+		ifNotEmpty: [ (self withColumns: anArrayOfArrays)
+				rowNames: anArrayOfRowNames;
+				yourself ]
+		ifEmpty: [ self withRowNames: anArrayOfRowNames ]
 ]
 
 { #category : #'instance creation' }
 DataFrame class >> withColumns: anArrayOfArrays rowNames: anArrayOfRowNames columnNames: anArrayOfColumnNames [
-
-	| df |
-	df := self withColumns: anArrayOfArrays.
-	df rowNames: anArrayOfRowNames.
-	df columnNames: anArrayOfColumnNames.
-	^ df
+	^ anArrayOfArrays
+		ifNotEmpty: [ (self withColumns: anArrayOfArrays)
+				rowNames: anArrayOfRowNames;
+				columnNames: anArrayOfColumnNames;
+				yourself ]
+		ifEmpty: [ self withRowNames: anArrayOfRowNames ]
 ]
 
 { #category : #'instance creation' }
@@ -261,11 +261,11 @@ DataFrame class >> withRows: anArrayOfArrays [
 
 { #category : #'instance creation' }
 DataFrame class >> withRows: anArrayOfArrays columnNames: anArrayOfColumnNames [
-
-	| df |
-	df := self withRows: anArrayOfArrays.
-	df columnNames: anArrayOfColumnNames.
-	^ df
+	^ anArrayOfArrays
+		ifNotEmpty: [ (self withRows: anArrayOfArrays)
+				columnNames: anArrayOfColumnNames;
+				yourself ]
+		ifEmpty: [ self withColumnNames: anArrayOfColumnNames ]
 ]
 
 { #category : #'instance creation' }
@@ -279,12 +279,12 @@ DataFrame class >> withRows: anArrayOfArrays rowNames: anArrayOfRowNames [
 
 { #category : #'instance creation' }
 DataFrame class >> withRows: anArrayOfArrays rowNames: anArrayOfRowNames columnNames: anArrayOfColumnNames [
-
-	| df |
-	df := self withRows: anArrayOfArrays.
-	df rowNames: anArrayOfRowNames.
-	df columnNames: anArrayOfColumnNames.
-	^ df
+	^ anArrayOfArrays
+		ifNotEmpty: [ (self withRows: anArrayOfArrays)
+				rowNames: anArrayOfRowNames;
+				columnNames: anArrayOfColumnNames;
+				yourself ]
+		ifEmpty: [ self withColumnNames: anArrayOfColumnNames ]
 ]
 
 { #category : #comparing }


### PR DESCRIPTION
creating empty dataframes with column/row names