### PR TITLE
Adding new test method: DataFrameTest>>#testRangeError

### DIFF
--- a/src/DataFrame-Tests/DataFrameTest.class.st
+++ b/src/DataFrame-Tests/DataFrameTest.class.st
@@ -2871,6 +2871,11 @@ DataFrameTest >> testPrintOn [
 ]
 
 { #category : #tests }
+DataFrameTest >> testRangeError [
+	self should: [ df range ] raise: MessageNotUnderstood	"Instance of Character did not understand #Barcelona"
+]
+
+{ #category : #tests }
 DataFrameTest >> testReject [
 	| actual expected |
 


### PR DESCRIPTION
I submit this pull request to suggest a new test method `DataFrameTest >> #testRangeError`.

#testRangeError makes it explicit that calling #range on a DataFrame object containing non-numerical columns throw an exception. In the current implementation, the pre-condition is implicit but with this new test it becomes an explicit part of the contract for DataFrame.

Note that these suggestions are adapted from a test amplification tool called SmallAmp (https://github.com/mabdi/small-amp). SmallAmp executes existing tests, sees which parts of the class under test are not covered and then suggests improvements on the test methods.

I hope you will accept this pull request. It would illustrate that SmallAmp makes relevant suggestions.

Mehrdad Abdi.