### PR TITLE
Allow booleans to be any case.

### DIFF
--- a/src/DataFrame-IO/DataFrame.extension.st
+++ b/src/DataFrame-IO/DataFrame.extension.st
@@ -11,9 +11,18 @@ DataFrame class >> readFrom: aLocation using: aDataFrameReader missingValuesStri
 	"Read data frame from a given location using a given DataFrameReader. Location can be a file reference, a database connection, or something else (depending on the implementation of the reader).
 	 Replaces the elements of aSet present in dataframe with nil"
 	
-	| df |
+	| df infer |
+	
+	"The readFrom method will infer types by default but we want this to happen after we convert things to nil
+	 so here we temporarily force it to false so that we can infer later 
+	"
+	aDataFrameReader shouldInferTypes ifTrue: [ infer := true  ].
+	aDataFrameReader shouldInferTypes: false.
 	df := aDataFrameReader readFrom: aLocation.
+	
 	df contents replaceMissingValuesStrings: aSet.
+	infer ifTrue: [  
+		DataFrameTypeDetector new detectTypesAndConvert: df].
 	^ df
 ]
 

--- a/src/DataFrame-IO/DataFrameCsvReader.class.st
+++ b/src/DataFrame-IO/DataFrameCsvReader.class.st
@@ -69,6 +69,17 @@ DataFrameCsvReader >> readColumnNamesWith: aReader [
 { #category : #reading }
 DataFrameCsvReader >> readFrom: aFileReference [
 	"Read data frame from a CSV file"
+	| df | 
+	df := self readFromInternal: aFileReference .
+	shouldInferTypes ifTrue: [
+		DataFrameTypeDetector new detectTypesAndConvert: df ].
+	^ df
+	
+]
+
+{ #category : #reading }
+DataFrameCsvReader >> readFromInternal: aFileReference [
+	"Read data frame from a CSV file"
 	| stream reader df |
 	stream := aFileReference readStream.
 	reader := NeoCSVReader on: stream.
@@ -80,8 +91,6 @@ DataFrameCsvReader >> readFrom: aFileReference [
 	reader close.
 	
 	df := self createDataFrame.
-	shouldInferTypes ifTrue: [
-		DataFrameTypeDetector new detectTypesAndConvert: df ].
 	^ df
 	
 ]

--- a/src/DataFrame-Type-Tests/DataFrameTypeDetectorTest.class.st
+++ b/src/DataFrame-Type-Tests/DataFrameTypeDetectorTest.class.st
@@ -41,6 +41,26 @@ DataFrameTypeDetectorTest >> testBooleanColumnWithNilsMixedCase [
 ]
 
 { #category : #tests }
+DataFrameTypeDetectorTest >> testBooleanColumnWithNumbers [
+	"Make sure that our boolean type detector doesn't return true for numbers"
+	| column expected actual |
+	column := #(1 2 3 4 5) asDataSeries.
+	expected := false.
+	actual := detector canAllBeBoolean: column.
+	self assert: actual equals: expected
+]
+
+{ #category : #tests }
+DataFrameTypeDetectorTest >> testBooleanColumnWithStrings [
+	"Make sure that our boolean type detector doesn't return true for strings that aren't true or false"
+	| column expected actual |
+	column := #('this' 'should' 'be' 'false') asDataSeries.
+	expected := false.
+	actual := detector canAllBeBoolean: column.
+	self assert: actual equals: expected
+]
+
+{ #category : #tests }
 DataFrameTypeDetectorTest >> testColumnAllNils [
 	| column expected actual |
 	column := #(nil nil nil nil) asDataSeries.

--- a/src/DataFrame-Type-Tests/DataFrameTypeDetectorTest.class.st
+++ b/src/DataFrame-Type-Tests/DataFrameTypeDetectorTest.class.st
@@ -32,6 +32,15 @@ DataFrameTypeDetectorTest >> testBooleanColumnWithNils [
 ]
 
 { #category : #tests }
+DataFrameTypeDetectorTest >> testBooleanColumnWithNilsMixedCase [
+	| column expected actual |
+	column := #('TRUE' 'False' 'true' nil) asDataSeries.
+	expected := #(true false true nil) asDataSeries.
+	actual := detector detectColumnTypeAndConvert: column.
+	self assert: actual equals: expected
+]
+
+{ #category : #tests }
 DataFrameTypeDetectorTest >> testColumnAllNils [
 	| column expected actual |
 	column := #(nil nil nil nil) asDataSeries.

--- a/src/DataFrame-Type/DataFrameTypeDetector.class.st
+++ b/src/DataFrame-Type/DataFrameTypeDetector.class.st
@@ -13,8 +13,13 @@ Class {
 
 { #category : #testing }
 DataFrameTypeDetector >> canAllBeBoolean: aDataSeries [
+   "Checks to see if all of the values in the column are strings of true or false (case insensitive) or nil"
 	^ aDataSeries
-		detect: [ :each | (each ~= 'true') & (each ~= 'false') & (each isNotNil)]
+		detect: [ :each | 
+			|eachLower | 
+			eachLower := [each asLowercase] on: Error do: [eachLower := nil].
+			(eachLower ~= 'true') & (eachLower ~= 'false') & (eachLower isNotNil) . 
+			]
 		ifFound: [ false ]
 		ifNone: [ true ].
 ]
@@ -28,13 +33,17 @@ DataFrameTypeDetector >> canAllBeDateAndTime: aDataSeries [
 
 { #category : #testing }
 DataFrameTypeDetector >> canAllBeNumber: aDataSeries [
+
 	| regex |
 	regex := '^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?$' asRegex.
-	
+
 	^ aDataSeries
-		detect: [ :each | [ each isNil ifTrue: [ false ] ifFalse: [ (regex matches: each) not ]] on: Error do: [ ^ false ] ]
-		ifFound: [ false ]
-		ifNone: [ true ]
+		  detect: [ :each | 
+			  [ each ifNil: [ false ] ifNotNil: [ (regex matches: each) not ] ]
+				  on: Error
+				  do: [ ^ false ] ]
+		  ifFound: [ false ]
+		  ifNone: [ true ]
 ]
 
 { #category : #testing }
@@ -56,7 +65,7 @@ DataFrameTypeDetector >> canAnyBeFloat: aDataSeries [
 DataFrameTypeDetector >> convertToBoolean: aDataSeries [
 	^ aDataSeries collect: [ :each |
 		each isNil
-			ifFalse: [ each = 'true' ] ]
+			ifFalse: [ each asLowercase = 'true' ] ]
 ]
 
 { #category : #converting }

--- a/src/DataFrame-Type/DataFrameTypeDetector.class.st
+++ b/src/DataFrame-Type/DataFrameTypeDetector.class.st
@@ -17,8 +17,8 @@ DataFrameTypeDetector >> canAllBeBoolean: aDataSeries [
 	^ aDataSeries
 		detect: [ :each | 
 			|eachLower | 
-			eachLower := [each asLowercase] on: Error do: [eachLower := nil].
-			(eachLower ~= 'true') & (eachLower ~= 'false') & (eachLower isNotNil) . 
+			eachLower := [each asLowercase] on: Error do: [eachLower := each].
+			((eachLower = 'true') | (eachLower = 'false') | (eachLower isNil)) not . 
 			]
 		ifFound: [ false ]
 		ifNone: [ true ].


### PR DESCRIPTION
Other programs output their boolean values in CSV files as uppercase (Excel, R) or sentence case (python). This change makes `DataFrameTypeDetector>>canAllBeBoolean` less stringent so that any case is accepted.