### PR TITLE
Explicit column types

### DIFF
--- a/src/DataFrame-IO/DataFrameCsvReader.class.st
+++ b/src/DataFrame-IO/DataFrameCsvReader.class.st
@@ -7,10 +7,27 @@ Class {
 		'shouldInferTypes',
 		'rowNames',
 		'rows',
-		'columnNames'
+		'columnNames',
+		'columnTypes'
 	],
 	#category : #'DataFrame-IO'
 }
+
+{ #category : #accessing }
+DataFrameCsvReader >> columnTypes [
+
+	^ columnTypes
+]
+
+{ #category : #accessing }
+DataFrameCsvReader >> columnTypes: columnTypeDefinition [
+	"column type definition can be a collection of blocks that take a string as an argument
+	 and convert it to another object.
+	"
+
+	columnTypes := columnTypeDefinition.
+	self shouldInferTypes: false.
+]
 
 { #category : #reading }
 DataFrameCsvReader >> createDataFrame [
@@ -51,11 +68,11 @@ DataFrameCsvReader >> includeRowNames: anObject [
 ]
 
 { #category : #initialization }
-DataFrameCsvReader >> initialize [ 
+DataFrameCsvReader >> initialize [
 	super initialize.
 	separator := self defaultSeparator.
 	includeRowNames := self defaultIncludeRowNames.
-	shouldInferTypes := self defaultShouldInferTypes.
+	shouldInferTypes := self defaultShouldInferTypes
 ]
 
 { #category : #reading }
@@ -80,19 +97,21 @@ DataFrameCsvReader >> readFrom: aFileReference [
 { #category : #reading }
 DataFrameCsvReader >> readFromInternal: aFileReference [
 	"Read data frame from a CSV file"
+
 	| stream reader df |
 	stream := aFileReference readStream.
 	reader := NeoCSVReader on: stream.
 	reader separator: self separator.
-	
+
+	"Assume that the columnTypes are a collection of neocsv methods like 
+	 addFloatField, or addIgnoredField"
+	columnTypes
+		ifNotNil: [ columnTypes do: [ :each | reader perform: each asSymbol ] ].
 	self readColumnNamesWith: reader.
 	self readRowsWith: reader.
-	
 	reader close.
-	
 	df := self createDataFrame.
 	^ df
-	
 ]
 
 { #category : #reading }

--- a/src/DataFrame-IO/DataFrameCsvReader.class.st
+++ b/src/DataFrame-IO/DataFrameCsvReader.class.st
@@ -1,3 +1,33 @@
+"
+I read csv files and convert them into DataFrames.
+
+I read text files containing multiple columns separated by a `separator` character. The first row will become the column names of the DataFrame. As I read the file I detect the type of data in the columns. I currently know how to detect and convert floating point numbers, integers, dates, and times. When I can't detect a consistent type for all rows of a column I leave the column type as a string.
+
+My behaviour can be modified by changing the column separator with `sepatator:`, turning off column type conversion using `shouldInferTypes: false`, or setting the first column as the row names using `includeRowNames: true`.
+
+Use the `readFrom:` message to read a stream and return a `DataFrame`:
+
+    reader := DataFrameCsvReader new.
+    reader readFrom: (FileLocator home / 'data.csv') 
+
+Modify my behaviour before calling `readFrom:`. The following example reads from a tab-separated stream and turns off any type conversions so all columns will be strings:
+
+    df := DataFrameCsvReader new separator: Character tab; 
+            shouldInferTypes: false;
+            readFrom: aStream
+
+It is also possible to specify the types of the columns in the file by passing a dictionary to `columnTypes:` message. Column type conversion only happens if `shouldInferTypes` is true. Refer to `DataFrameTypeDetector` for more information about the format of the dictionary to be given to `columnTypes:`.
+ 
+Internal Representation and Key Implementation Points.
+
+    Instance Variables
+	includeRowNames:		Boolean
+	separator:		Character
+	shouldInferTypes:		Boolean
+
+
+    Implementation Points
+"
 Class {
 	#name : #DataFrameCsvReader,
 	#superclass : #DataFrameReader,
@@ -7,27 +37,10 @@ Class {
 		'shouldInferTypes',
 		'rowNames',
 		'rows',
-		'columnNames',
-		'columnTypes'
+		'columnNames'
 	],
 	#category : #'DataFrame-IO'
 }
-
-{ #category : #accessing }
-DataFrameCsvReader >> columnTypes [
-
-	^ columnTypes
-]
-
-{ #category : #accessing }
-DataFrameCsvReader >> columnTypes: columnTypeDefinition [
-	"column type definition can be a collection of blocks that take a string as an argument
-	 and convert it to another object.
-	"
-
-	columnTypes := columnTypeDefinition.
-	self shouldInferTypes: false.
-]
 
 { #category : #reading }
 DataFrameCsvReader >> createDataFrame [
@@ -72,7 +85,8 @@ DataFrameCsvReader >> initialize [
 	super initialize.
 	separator := self defaultSeparator.
 	includeRowNames := self defaultIncludeRowNames.
-	shouldInferTypes := self defaultShouldInferTypes
+	shouldInferTypes := self defaultShouldInferTypes.
+	columnTypes := Dictionary new.
 ]
 
 { #category : #reading }
@@ -89,7 +103,7 @@ DataFrameCsvReader >> readFrom: aFileReference [
 	| df | 
 	df := self readFromInternal: aFileReference .
 	shouldInferTypes ifTrue: [
-		DataFrameTypeDetector new detectTypesAndConvert: df ].
+		DataFrameTypeDetector new columnTypes: columnTypes; detectTypesAndConvert: df ].
 	^ df
 	
 ]
@@ -103,10 +117,6 @@ DataFrameCsvReader >> readFromInternal: aFileReference [
 	reader := NeoCSVReader on: stream.
 	reader separator: self separator.
 
-	"Assume that the columnTypes are a collection of neocsv methods like 
-	 addFloatField, or addIgnoredField"
-	columnTypes
-		ifNotNil: [ columnTypes do: [ :each | reader perform: each asSymbol ] ].
 	self readColumnNamesWith: reader.
 	self readRowsWith: reader.
 	reader close.

--- a/src/DataFrame-IO/DataFrameReader.class.st
+++ b/src/DataFrame-IO/DataFrameReader.class.st
@@ -1,8 +1,26 @@
 Class {
 	#name : #DataFrameReader,
 	#superclass : #Object,
+	#instVars : [
+		'columnTypes'
+	],
 	#category : #'DataFrame-IO'
 }
+
+{ #category : #accessing }
+DataFrameReader >> columnTypes [
+
+	^ columnTypes
+]
+
+{ #category : #accessing }
+DataFrameReader >> columnTypes: columnTypeDefinition [
+	"column type definition can be a collection of blocks that take a string as an argument
+	 and convert it to another object.
+	"
+
+	columnTypes := columnTypeDefinition.
+]
 
 { #category : #reading }
 DataFrameReader >> readFrom: aLocation [

--- a/src/DataFrame-Type-Tests/DataFrameTypeDetectorTest.class.st
+++ b/src/DataFrame-Type-Tests/DataFrameTypeDetectorTest.class.st
@@ -97,9 +97,9 @@ DataFrameTypeDetectorTest >> testExplicitType [
 	df columnNames: #(temperature precipitation type).
 	detector
 		columnTypes:
-			{('temperature' -> 'float').
-			('precipitation' -> 'boolean').
-			('type' -> 'string')} asDictionary.
+			{('temperature' -> Float).
+			('precipitation' -> Boolean).
+			('type' -> String)} asDictionary.
 	expected := DataFrame
 		withColumns:
 			#(#(2.4 0.5 -1.2 -2.3 3.2) #(true true true false true) #('rain' 'rain' 'snow' '-' 'rain')).
@@ -120,10 +120,10 @@ DataFrameTypeDetectorTest >> testExplicitTypeCustomConversion [
 	df columnNames: #(temperature precipitation type).
 	detector
 		columnTypes:
-			{('temperature' -> 'float').
+			{('temperature' -> Float).
 			('precipitation'
 				-> [ :array | array collect: [ :each | each asInteger = 1 ] ]).
-			('type' -> 'string')} asDictionary.
+			('type' -> String)} asDictionary.
 	expected := DataFrame
 		withColumns:
 			#(#(2.4 0.5 -1.2 -2.3 3.2) #(true true true false true) #('rain' 'rain' 'snow' '-' 'rain')).
@@ -142,9 +142,9 @@ DataFrameTypeDetectorTest >> testExplicitTypeGuess [
 	df columnNames: #(temperature precipitation type).
 	detector
 		columnTypes:
-			{('temperature' -> 'guess').
-			('precipitation' -> 'boolean').
-			('type' -> 'string')} asDictionary.
+			{('temperature' -> nil).
+			('precipitation' -> Boolean).
+			('type' -> String)} asDictionary.
 	expected := DataFrame
 		withColumns:
 			#(#(2.4 0.5 -1.2 -2.3 3.2) #(true true true false true) #('rain' 'rain' 'snow' '-' 'rain')).
@@ -163,8 +163,8 @@ DataFrameTypeDetectorTest >> testExplicitTypeMissing [
 	df columnNames: #(temperature precipitation type).
 	detector
 		columnTypes:
-			{('precipitation' -> 'boolean').
-			('type' -> 'string')} asDictionary.
+			{('precipitation' -> Boolean).
+			('type' -> String)} asDictionary.
 	expected := DataFrame
 		withColumns:
 			#(#(2.4 0.5 -1.2 -2.3 3.2) #(true true true false true) #('rain' 'rain' 'snow' '-' 'rain')).

--- a/src/DataFrame-Type-Tests/DataFrameTypeDetectorTest.class.st
+++ b/src/DataFrame-Type-Tests/DataFrameTypeDetectorTest.class.st
@@ -133,6 +133,26 @@ DataFrameTypeDetectorTest >> testExplicitTypeCustomConversion [
 ]
 
 { #category : #tests }
+DataFrameTypeDetectorTest >> testExplicitTypeMissing [
+	"Test that DataFrameTypeDetector can be convert types with guessing"
+	| df expected |
+	df := DataFrame
+		withColumns:
+			#(#('2.4' '0.5' '-1.2' '-2.3' '3.2') #('true' 'true' 'true' 'false' 'true') #('rain' 'rain' 'snow' '-' 'rain')).
+	df columnNames: #(temperature precipitation type).
+	detector
+		columnTypes:
+			{('precipitation' -> 'boolean').
+			('type' -> 'string')} asDictionary.
+	expected := DataFrame
+		withColumns:
+			#(#(2.4 0.5 -1.2 -2.3 3.2) #(true true true false true) #('rain' 'rain' 'snow' '-' 'rain')).
+	expected columnNames: #(temperature precipitation type).
+	detector detectTypesAndConvert: df.
+	self assert: df equals: expected
+]
+
+{ #category : #tests }
 DataFrameTypeDetectorTest >> testFloatColumn [
 	| column expected actual |
 	column := #('1.2' '3.3' '-10.1' '0.0') asDataSeries.

--- a/src/DataFrame-Type-Tests/DataFrameTypeDetectorTest.class.st
+++ b/src/DataFrame-Type-Tests/DataFrameTypeDetectorTest.class.st
@@ -133,6 +133,27 @@ DataFrameTypeDetectorTest >> testExplicitTypeCustomConversion [
 ]
 
 { #category : #tests }
+DataFrameTypeDetectorTest >> testExplicitTypeGuess [
+	"Test that DataFrameTypeDetector can be convert types with guessing"
+	| df expected |
+	df := DataFrame
+		withColumns:
+			#(#('2.4' '0.5' '-1.2' '-2.3' '3.2') #('true' 'true' 'true' 'false' 'true') #('rain' 'rain' 'snow' '-' 'rain')).
+	df columnNames: #(temperature precipitation type).
+	detector
+		columnTypes:
+			{('temperature' -> 'guess').
+			('precipitation' -> 'boolean').
+			('type' -> 'string')} asDictionary.
+	expected := DataFrame
+		withColumns:
+			#(#(2.4 0.5 -1.2 -2.3 3.2) #(true true true false true) #('rain' 'rain' 'snow' '-' 'rain')).
+	expected columnNames: #(temperature precipitation type).
+	detector detectTypesAndConvert: df.
+	self assert: df equals: expected
+]
+
+{ #category : #tests }
 DataFrameTypeDetectorTest >> testExplicitTypeMissing [
 	"Test that DataFrameTypeDetector can be convert types with guessing"
 	| df expected |

--- a/src/DataFrame-Type-Tests/DataFrameTypeDetectorTest.class.st
+++ b/src/DataFrame-Type-Tests/DataFrameTypeDetectorTest.class.st
@@ -88,6 +88,51 @@ DataFrameTypeDetectorTest >> testDateAndTimeColumnWithNils [
 ]
 
 { #category : #tests }
+DataFrameTypeDetectorTest >> testExplicitType [
+	"Test that DataFrameTypeDetector can be convert types without guessing"
+	| df expected |
+	df := DataFrame
+		withColumns:
+			#(#('2.4' '0.5' '-1.2' '-2.3' '3.2') #('true' 'true' 'true' 'false' 'true') #('rain' 'rain' 'snow' '-' 'rain')).
+	df columnNames: #(temperature precipitation type).
+	detector
+		columnTypes:
+			{('temperature' -> 'float').
+			('precipitation' -> 'boolean').
+			('type' -> 'string')} asDictionary.
+	expected := DataFrame
+		withColumns:
+			#(#(2.4 0.5 -1.2 -2.3 3.2) #(true true true false true) #('rain' 'rain' 'snow' '-' 'rain')).
+	expected columnNames: #(temperature precipitation type).
+	detector detectTypesAndConvert: df.
+	self assert: df equals: expected
+]
+
+{ #category : #tests }
+DataFrameTypeDetectorTest >> testExplicitTypeCustomConversion [
+	"Test that DataFrameTypeDetector can be convert types
+	 without guessing using a user supplied block"
+
+	| df expected |
+	df := DataFrame
+		withColumns:
+			#(#('2.4' '0.5' '-1.2' '-2.3' '3.2') #('1' '1' '1' '0' '1') #('rain' 'rain' 'snow' '-' 'rain')).
+	df columnNames: #(temperature precipitation type).
+	detector
+		columnTypes:
+			{('temperature' -> 'float').
+			('precipitation'
+				-> [ :array | array collect: [ :each | each asInteger = 1 ] ]).
+			('type' -> 'string')} asDictionary.
+	expected := DataFrame
+		withColumns:
+			#(#(2.4 0.5 -1.2 -2.3 3.2) #(true true true false true) #('rain' 'rain' 'snow' '-' 'rain')).
+	expected columnNames: #(temperature precipitation type).
+	detector detectTypesAndConvert: df.
+	self assert: df equals: expected
+]
+
+{ #category : #tests }
 DataFrameTypeDetectorTest >> testFloatColumn [
 	| column expected actual |
 	column := #('1.2' '3.3' '-10.1' '0.0') asDataSeries.

--- a/src/DataFrame-Type/DataFrameTypeDetector.class.st
+++ b/src/DataFrame-Type/DataFrameTypeDetector.class.st
@@ -3,11 +3,32 @@ I am a smart type detector. I receive a column of string values such as #('5' '-
 
 My typical application is to detect data types of data frame columns after that data frame was read from a CSV file.
 
-I support the following types: Integer, Float, Boolean, Time, DateAndTime, String
+I support the following types: Integer, Float, Boolean, Time, DateAndTime, String.
+
+Instead of guessing the column types I can also be given a mapping of the column names and their types
+in which case I skip detection and just convert. To set the types use my `columnTypes:` message.
+
+    detector := DataFrameTypeDetector new.
+    detector columnTypes: { 'columnName1' -> 'string'. 'columnName2' -> 'boolean' } asDictionary.
+
+    detector detectTypesAndConvert: aDataFrame
+	
+If a column name isn't specified in the columnTypes then I will guess the type. As well as the 
+standard types I can also perform custom type conversion if the value is a block.
+
+    detector columnTypes: { 'columnName1' -> [:series | series collect: [:each | each asCustomType]]. 'columnName2' -> 'boolean' } asDictionary.	
+    detector detectTypesAndConvert: aDataFrame
+
+The block takes a single argument, the column, and should return the column as well. I also handle 
+mixing the standard conversion types and custom converters.    
 "
 Class {
 	#name : #DataFrameTypeDetector,
 	#superclass : #Object,
+	#instVars : [
+		'columnTypes',
+		'typeMapping'
+	],
 	#category : #'DataFrame-Type'
 }
 
@@ -61,6 +82,16 @@ DataFrameTypeDetector >> canAnyBeFloat: aDataSeries [
 		ifNone: [ false ].
 ]
 
+{ #category : #accessing }
+DataFrameTypeDetector >> columnTypes [
+	^columnTypes
+]
+
+{ #category : #accessing }
+DataFrameTypeDetector >> columnTypes: aCollection [
+	columnTypes := aCollection
+]
+
 { #category : #converting }
 DataFrameTypeDetector >> convertToBoolean: aDataSeries [
 	^ aDataSeries collect: [ :each |
@@ -109,9 +140,42 @@ DataFrameTypeDetector >> detectColumnTypeAndConvert: aDataSeries [
 
 { #category : #'public API' }
 DataFrameTypeDetector >> detectTypesAndConvert: aDataFrame [
-	aDataFrame columnNames do: [ :columnName |
-		aDataFrame column: columnName put: (
-			self detectColumnTypeAndConvert: (aDataFrame column: columnName)) asArray ].
-		
-	aDataFrame rowNames: (self detectColumnTypeAndConvert: aDataFrame rowNames).
+	aDataFrame columnNames
+		do: [ :columnName | 
+			| thisColumnType |
+			"Get the user given column type for this column name and if it wasn't
+			 given then use the default type detection"
+			thisColumnType := columnTypes
+				at: columnName
+				ifAbsent: [ :array | self detectColumnTypeAndConvert: array ].
+			"We allow users to submit either a string which is one of the standard 
+			 types that we know how to convert or a block which is for custom type
+			 conversion. Test if it's a block here and if not assume that we can
+			 look it up in the type mapping and assign one of the standard type
+			 converting blocks."
+			thisColumnType isBlock
+				ifFalse: [ thisColumnType := typeMapping at: thisColumnType ].
+			"Assign the column with the converted type by passing the original
+			 column to the block for type conversion"
+			aDataFrame
+				column: columnName
+				put: (thisColumnType value: (aDataFrame column: columnName)) asArray ].
+	aDataFrame
+		rowNames: (self detectColumnTypeAndConvert: aDataFrame rowNames)
+]
+
+{ #category : #initialization }
+DataFrameTypeDetector >> initialize [
+	columnTypes := Dictionary new.
+	typeMapping := Dictionary
+		newFrom:
+			{('boolean' -> [ :array | self convertToBoolean: array ]).
+			('float' -> [ :array | self convertToFloat: array ]).
+			('integer' -> [ :array | self convertToInteger: array ]).
+			('time' -> [ :array | self convertToTime: array ]).
+			('date' -> [ :array | self convertToDateAndTime: array ]).
+			('string' -> [ :array | array ]).
+			('guess' -> [ :array | self detectColumnTypeAndConvert: array ])}.
+	"Alias dateandtime to date"
+	typeMapping at: 'dateandtime' put: (typeMapping at: 'date')
 ]

--- a/src/DataFrame-Type/DataFrameTypeDetector.class.st
+++ b/src/DataFrame-Type/DataFrameTypeDetector.class.st
@@ -12,15 +12,31 @@ in which case I skip detection and just convert. To set the types use my `column
     detector columnTypes: { 'columnName1' -> 'string'. 'columnName2' -> 'boolean' } asDictionary.
 
     detector detectTypesAndConvert: aDataFrame
-	
-If a column name isn't specified in the columnTypes then I will guess the type. As well as the 
-standard types I can also perform custom type conversion if the value is a block.
 
-    detector columnTypes: { 'columnName1' -> [:series | series collect: [:each | each asCustomType]]. 'columnName2' -> 'boolean' } asDictionary.	
+The keys of this mapping must be the column name and the values can be either a block (to perform custom type conversion) or one of the following strings that implement one of my standard type conversions:
+
+- string: this does not perform any conversion.
+- integer: convert to an Integer object.
+- float: convert to a Float object.
+- boolean: convert to a Boolean object.
+- date: convert to a DateAndTime object.
+- time: convert to a Time object.
+- dateandtime: alias for dateandtime.
+- guess: will attempt to guess the type of the column from one of the listed types above. This is the default if no conversion is given.
+	
+As well as the standard types I can also perform custom type conversion if the value is a block.
+
+    types := { 'columnName' -> [:series | series collect: [:each | each asCustomType]]. } asDictionary.
+    detector columnTypes: types	
     detector detectTypesAndConvert: aDataFrame
 
 The block takes a single argument, the column, and should return the column as well. I also handle 
-mixing the standard conversion types and custom converters.    
+mixing the standard conversion types and custom converters in the provided types dictionary:
+
+    types := { 'columnName2' -> 'integer' . 'columnName2' -> [:series | series collect: [:each | each asCustomType]]. } asDictionary.
+    detector columnTypes: types	
+    detector detectTypesAndConvert: aDataFrame
+ 
 "
 Class {
 	#name : #DataFrameTypeDetector,

--- a/src/DataFrame-Type/DataFrameTypeDetector.class.st
+++ b/src/DataFrame-Type/DataFrameTypeDetector.class.st
@@ -9,20 +9,19 @@ Instead of guessing the column types I can also be given a mapping of the column
 in which case I skip detection and just convert. To set the types use my `columnTypes:` message.
 
     detector := DataFrameTypeDetector new.
-    detector columnTypes: { 'columnName1' -> 'string'. 'columnName2' -> 'boolean' } asDictionary.
+    detector columnTypes: { 'columnName1' -> String. 'columnName2' -> Boolean } asDictionary.
 
     detector detectTypesAndConvert: aDataFrame
 
 The keys of this mapping must be the column name and the values can be either a block (to perform custom type conversion) or one of the following strings that implement one of my standard type conversions:
 
-- string: this does not perform any conversion.
-- integer: convert to an Integer object.
-- float: convert to a Float object.
-- boolean: convert to a Boolean object.
-- date: convert to a DateAndTime object.
-- time: convert to a Time object.
-- dateandtime: alias for dateandtime.
-- guess: will attempt to guess the type of the column from one of the listed types above. This is the default if no conversion is given.
+- String: this does not perform any conversion.
+- Integer: convert to an Integer object.
+- Float: convert to a Float object.
+- Boolean: convert to a Boolean object.
+- DateAndTime: convert to a DateAndTime object.
+- Time: convert to a Time object.
+- nil: will attempt to guess the type of the column from one of the listed types above. This is the default if no conversion is given.
 	
 As well as the standard types I can also perform custom type conversion if the value is a block.
 
@@ -33,7 +32,7 @@ As well as the standard types I can also perform custom type conversion if the v
 The block takes a single argument, the column, and should return the column as well. I also handle 
 mixing the standard conversion types and custom converters in the provided types dictionary:
 
-    types := { 'columnName2' -> 'integer' . 'columnName2' -> [:series | series collect: [:each | each asCustomType]]. } asDictionary.
+    types := { 'columnName2' -> Integer . 'columnName2' -> [:series | series collect: [:each | each asCustomType]]. } asDictionary.
     detector columnTypes: types	
     detector detectTypesAndConvert: aDataFrame
  
@@ -185,13 +184,11 @@ DataFrameTypeDetector >> initialize [
 	columnTypes := Dictionary new.
 	typeMapping := Dictionary
 		newFrom:
-			{('boolean' -> [ :array | self convertToBoolean: array ]).
-			('float' -> [ :array | self convertToFloat: array ]).
-			('integer' -> [ :array | self convertToInteger: array ]).
-			('time' -> [ :array | self convertToTime: array ]).
-			('date' -> [ :array | self convertToDateAndTime: array ]).
-			('string' -> [ :array | array ]).
-			('guess' -> [ :array | self detectColumnTypeAndConvert: array ])}.
-	"Alias dateandtime to date"
-	typeMapping at: 'dateandtime' put: (typeMapping at: 'date')
+			{(Boolean -> [ :array | self convertToBoolean: array ]).
+			(Float -> [ :array | self convertToFloat: array ]).
+			(Integer -> [ :array | self convertToInteger: array ]).
+			(Time -> [ :array | self convertToTime: array ]).
+			(DateAndTime -> [ :array | self convertToDateAndTime: array ]).
+			(String -> [ :array | array ]).
+			(nil -> [ :array | self detectColumnTypeAndConvert: array ])}.
 ]

--- a/src/DataFrame-Type/DataFrameTypeDetector.class.st
+++ b/src/DataFrame-Type/DataFrameTypeDetector.class.st
@@ -163,7 +163,7 @@ DataFrameTypeDetector >> detectTypesAndConvert: aDataFrame [
 			 given then use the default type detection"
 			thisColumnType := columnTypes
 				at: columnName
-				ifAbsent: [ :array | self detectColumnTypeAndConvert: array ].
+				ifAbsent: [ [:array | self detectColumnTypeAndConvert: array ]].
 			"We allow users to submit either a string which is one of the standard 
 			 types that we know how to convert or a block which is for custom type
 			 conversion. Test if it's a block here and if not assume that we can


### PR DESCRIPTION
This pull request adds in the ability for `DataFrameCsvReader` and `DataFrameTypeDetector` to be given a mapping of types. This allows skipping the (potentially slow) process of guessing the types of the columns. The `columnTypes:` message has been added to both classes which takes a dictionary with the following format:

```
{
 <columnName> -> <ClassName>
 <columnName> -> <block>
}
```

where the column name is given as the key and the values can be either a string, specifying one of the standard types that `DataFrameTypeDetector` performs; or a block, which performs custom conversion. The standard types map on to one of the conversion messages already implemented whereas if a block is given then it is assumed to take the column as a the argument and return a transformed version of the column. If a column name isn't mentioned in the types mapping (or if no type mapping is provided) then the current procedure of guessing the column type is run.


## Example
```smalltalk
reader := DataFrameCsvReader new.
types := {'col1' -> Integer. 'col2' -> Float. 'col3' -> Boolean} asDictionary
reader columnTypes: types
reader readFrom: aStream
```

