### PR TITLE
Added cumulativeSum method (tested!)

### DIFF
--- a/src/DataFrame-Tests/DataSeriesTest.class.st
+++ b/src/DataFrame-Tests/DataSeriesTest.class.st
@@ -1857,13 +1857,19 @@ DataSeriesTest >> testStatsAverage [
 { #category : #statistics }
 DataSeriesTest >> testStatsCumulativeSum [
 
-	| actual expected |
-	actual := DataSeries withValues: #( nil 3 4 7 nil 2 4 0 3 nil 2 9 ).
-	expected := DataSeries withValues:
-		            #( 0 3 7 14 14 16 20 20 23 23 25 34 ).
-	expected name: #cumulativeSum.
+	| seriesWithNils expected |
+	
+	seriesWithNils := DataSeries
+		withKeys: #(a b c d e f g h i j k l)
+		values: #(nil 3 4 7 nil 2 4 0 3 nil 2 9)
+		name: 'numbers'.
+		
+	expected := DataSeries
+		withKeys: #(a b c d e f g h i j k l)
+		values: #(0 3 7 14 14 16 20 20 23 23 25 34)
+		name: 'numbers'.
 
-	self assert: actual cumulativeSum equals: expected
+	self assert: seriesWithNils cumulativeSum equals: expected
 ]
 
 { #category : #statistics }

--- a/src/DataFrame-Tests/DataSeriesTest.class.st
+++ b/src/DataFrame-Tests/DataSeriesTest.class.st
@@ -1855,6 +1855,18 @@ DataSeriesTest >> testStatsAverage [
 ]
 
 { #category : #statistics }
+DataSeriesTest >> testStatsCumulativeSum [
+
+	| actual expected |
+	actual := DataSeries withValues: #( nil 3 4 7 nil 2 4 0 3 nil 2 9 ).
+	expected := DataSeries withValues:
+		            #( 0 3 7 14 14 16 20 20 23 23 25 34 ).
+	expected name: #cumulativeSum.
+
+	self assert: actual cumulativeSum equals: expected
+]
+
+{ #category : #statistics }
 DataSeriesTest >> testStatsFirstQuartile [
 
 	self assert: series firstQuartile equals: 7.

--- a/src/DataFrame/DataSeries.class.st
+++ b/src/DataFrame/DataSeries.class.st
@@ -220,18 +220,14 @@ DataSeries >> crossTabulateWith: aSeries [
 
 { #category : #statistics }
 DataSeries >> cumulativeSum [
+	"Calculate the cumulative sum of a data series and return a new data series with keys as self keys and values as cumulative sum"
 
-	"calculates cumulative sum of a dataseries and returns a new dataseries with keys as self keys and values as cumulative sum"
-
-	| sum cumulativeSumSeries |
+	| sum |
 	sum := 0.
 
-	cumulativeSumSeries := DataSeries withValues:
-		                       (self collect: [ :each | 
-			                        each ifNotNil: [ sum := sum + each ].
-			                        sum ]).
-	cumulativeSumSeries name: #cumulativeSum.
-	^ cumulativeSumSeries
+	^ self collect: [ :each |
+		each ifNotNil: [ sum := sum + each ].
+		sum ].
 ]
 
 { #category : #defaults }

--- a/src/DataFrame/DataSeries.class.st
+++ b/src/DataFrame/DataSeries.class.st
@@ -218,6 +218,22 @@ DataSeries >> crossTabulateWith: aSeries [
 	^ df
 ]
 
+{ #category : #statistics }
+DataSeries >> cumulativeSum [
+
+	"calculates cumulative sum of a dataseries and returns a new dataseries with keys as self keys and values as cumulative sum"
+
+	| sum cumulativeSumSeries |
+	sum := 0.
+
+	cumulativeSumSeries := DataSeries withValues:
+		                       (self collect: [ :each | 
+			                        each ifNotNil: [ sum := sum + each ].
+			                        sum ]).
+	cumulativeSumSeries name: #cumulativeSum.
+	^ cumulativeSumSeries
+]
+
 { #category : #defaults }
 DataSeries >> defaultHeadTailSize [
 	^ 5


### PR DESCRIPTION
Cumulative Sum in Statistics is used to show the summation of data as it grows with time (updated when every new number is added to the sequence).  It's significance is used to measure total contribution so far of a measure against time, majorly used in 
Statistical Anaysis.
`DataSeries >> cumulativeSum`
`Category : statistics`
Example : 
`series := DataSeries withValues: #( nil 1 2 3 nil 4 5 0 6 nil 7 8 ).`
`series cumulativeSum.`
Returns a DataSeries as below:
| Key | Value |
| --- | --- |
| 1 | 0 |
| 2 | 1 |
| 3 | 3 |
| 4 | 6 |
| 5 | 6 |
| 6 | 10 |
| 7 | 15 |
| 8 | 15 |
| 9 | 21 |
| 10 | 21 |
| 11 | 28 |
| 12 | 36 |


