### PR TITLE
implemented columns method

### DIFF
--- a/src/DataFrame-Tests/DataFrameTest.class.st
+++ b/src/DataFrame-Tests/DataFrameTest.class.st
@@ -661,23 +661,13 @@ DataFrameTest >> testColumnTransformNotFound [
 { #category : #tests }
 DataFrameTest >> testColumns [
 
-	| columnNames actualDataFrame expectedDataFrame expectedCollection |
-	columnNames := #( City BeenThere ).
+	| expectedCollection |
 
-	expectedDataFrame := DataFrame withRows:
-		                     #( #( Barcelona true ) #( Dubai true )
-		                        #( London false ) ).
-
-	expectedDataFrame rowNames: df rowNames.
-	expectedDataFrame columnNames: columnNames.
-
-	actualDataFrame := df columns: columnNames.
-
-	self assert: actualDataFrame equals: expectedDataFrame.
-
-	expectedCollection := #( #( Barcelona Dubai London )
-	                         #( 1.609 2.789 8.788 )
-	                         #( true true false ) ).
+	expectedCollection := #(
+		(Barcelona Dubai London)
+	   (1.609 2.789 8.788)
+	   (true true false)).
+	
 	self assert: df columns equals: expectedCollection
 ]
 
@@ -824,6 +814,26 @@ DataFrameTest >> testColumnsPut [
 	
 	dataFrame columns: #(type temperature) put: newColumns.
 	self assert: dataFrame equals: expected.
+]
+
+{ #category : #tests }
+DataFrameTest >> testColumnsSubset [
+
+	| columnNames actualDataFrame expectedDataFrame |
+	
+	columnNames := #(City BeenThere).
+	
+	expectedDataFrame := DataFrame withRows: #(
+		(Barcelona true)
+   		(Dubai true)
+   		(London false)).
+		
+	expectedDataFrame rowNames: df rowNames.
+	expectedDataFrame columnNames: columnNames.
+	
+	actualDataFrame := df columns: columnNames.
+	
+	self assert: actualDataFrame equals: expectedDataFrame.
 ]
 
 { #category : #tests }

--- a/src/DataFrame-Tests/DataFrameTest.class.st
+++ b/src/DataFrame-Tests/DataFrameTest.class.st
@@ -661,10 +661,24 @@ DataFrameTest >> testColumnTransformNotFound [
 { #category : #tests }
 DataFrameTest >> testColumns [
 
-	| expected |
-	expected := #( #( Barcelona Dubai London )
-	               #( 1.609 2.789 8.788 ) #( true true false ) ).
-	self assert: df columns equals: expected
+	| columnNames actualDataFrame expectedDataFrame expectedCollection |
+	columnNames := #( City BeenThere ).
+
+	expectedDataFrame := DataFrame withRows:
+		                     #( #( Barcelona true ) #( Dubai true )
+		                        #( London false ) ).
+
+	expectedDataFrame rowNames: df rowNames.
+	expectedDataFrame columnNames: columnNames.
+
+	actualDataFrame := df columns: columnNames.
+
+	self assert: actualDataFrame equals: expectedDataFrame.
+
+	expectedCollection := #( #( Barcelona Dubai London )
+	                         #( 1.609 2.789 8.788 )
+	                         #( true true false ) ).
+	self assert: df columns equals: expectedCollection
 ]
 
 { #category : #tests }

--- a/src/DataFrame-Tests/DataFrameTest.class.st
+++ b/src/DataFrame-Tests/DataFrameTest.class.st
@@ -661,21 +661,10 @@ DataFrameTest >> testColumnTransformNotFound [
 { #category : #tests }
 DataFrameTest >> testColumns [
 
-	| columnNames actualDataFrame expectedDataFrame |
-	
-	columnNames := #(City BeenThere).
-	
-	expectedDataFrame := DataFrame withRows: #(
-		(Barcelona true)
-   		(Dubai true)
-   		(London false)).
-		
-	expectedDataFrame rowNames: df rowNames.
-	expectedDataFrame columnNames: columnNames.
-	
-	actualDataFrame := df columns: columnNames.
-	
-	self assert: actualDataFrame equals: expectedDataFrame.
+	| expected |
+	expected := #( #( Barcelona Dubai London )
+	               #( 1.609 2.789 8.788 ) #( true true false ) ).
+	self assert: df columns equals: expected
 ]
 
 { #category : #tests }

--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -602,6 +602,14 @@ DataFrame >> columnNames: anArray [
 ]
 
 { #category : #accessing }
+DataFrame >> columns [
+
+	"Returns a collection of all columns"
+
+	^ self asArrayOfColumns
+]
+
+{ #category : #accessing }
 DataFrame >> columns: anArrayOfNames [
 	
 	| anArrayOfNumbers |


### PR DESCRIPTION
Returns a collection of all columns. 
`df := DataFrame withRows: #( #('Alice' 24 'F') #('Bob' 30 'M') #('David' 22 'M').`
`df columns.`
This returns a collection as below.
`#( #('Alice' 'Bob' 'David') #(24 30 22) #('M' 'F' 'M') ).`
