### PR TITLE
One feature was duplicated because a PR was pending and someone added…

### DIFF
--- a/src/DataFrame-Tests/DataFrameTest.class.st
+++ b/src/DataFrame-Tests/DataFrameTest.class.st
@@ -3410,27 +3410,6 @@ DataFrameTest >> testRenameRowToNotFound [
 		raise: Error.
 ]
 
-{ #category : #tests }
-DataFrameTest >> testReplaceAllNilsWithZeros [
-
-	| expected |
-	df := DataFrame withRows: #(
-		(Barcelona 1.609 nil)
-   		(Dubai nil nil)
-   		(nil 8.788 false)).
-		
-	df columnNames: #(City Population BeenThere).
-	
-	expected := DataFrame withRows: #(
-		(Barcelona 1.609 0)
-   		(Dubai 0 0)
-   		(0 8.788 false)).
-	
-	expected columnNames: #(City Population BeenThere).
-	
-	self assert: df replaceAllNilsWithZeros equals: expected.
-]
-
 { #category : #replacing }
 DataFrameTest >> testReplaceNilsWith [ 
 	

--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -1381,14 +1381,6 @@ DataFrame >> removeColumnsOfRowElementsSatisfying: aBlock onRow: rowNumber [
 	self numberOfColumns = 0 ifTrue: [ rowNames removeAll ].
 ]
 
-{ #category : #removing }
-DataFrame >> removeColumnsOfRowElementsSatisfing: aBlock onRowNamed: rowName [
-
-	| index |
-	index := self indexOfRowNamed: rowName.
-	self removeColumnsOfRowElementsSatisfing: aBlock onRow: index.
-]
-
 { #category : #'handling nils' }
 DataFrame >> removeColumnsWithNilsAtRow: rowNumber [
 	self removeColumnsOfRowElementsSatisfying: [ :ele | ele isNil ] onRow: rowNumber.
@@ -1490,6 +1482,14 @@ DataFrame >> renameRow: oldName to: newName [
 	self rowNames at: index put: newName.
 ]
 
+{ #category : #'handling nils' }
+DataFrame >> replaceAllNilsWithZeros [
+
+	self deprecated: 'Use #replaceNilsWithZero instead.' transformWith: '`@receiver replaceAllNilsWithZeros' -> '`@receiver replaceNilsWithZero'.
+
+	self replaceNilsWithZero
+]
+
 { #category : #replacing }
 DataFrame >> replaceNilsWith: anObject [
 			
@@ -1556,13 +1556,6 @@ DataFrame >> replaceNilsWithPreviousRowValue [
 DataFrame >> replaceNilsWithZero [
 			
 	self replaceNilsWith: 0
-]
-
-{ #category : #'handling nils' }
-DataFrame >> replaceAllNilsWithZeros [
-
-	self columnNames do: [ :name | 
-		self column: name put: (self column: name) replaceNilsWithZeros ]
 ]
 
 { #category : #splitjoin }


### PR DESCRIPTION
… a feature of the PR in dataframe.

This commit deprecated one way to only use the other.