### PR TITLE
Add DataFrame>>#atAll: to be polymorphic with other sequenceable coll…

### DIFF
--- a/src/DataFrame-Tests/DataFrameTest.class.st
+++ b/src/DataFrame-Tests/DataFrameTest.class.st
@@ -350,6 +350,27 @@ DataFrameTest >> testAt [
 ]
 
 { #category : #tests }
+DataFrameTest >> testAtAll [
+
+	| rowNumbers actualDataFrame expectedDataFrame |
+
+	rowNumbers := #(1 3).
+
+	expectedDataFrame := DataFrame withRows: #(
+		(Barcelona 1.609 true)
+   		(London 8.788 false)).
+
+	expectedDataFrame rowNames:
+		(rowNumbers collect: [ :i |
+			df rowNames at: i ]).
+	expectedDataFrame columnNames: df columnNames.
+
+	actualDataFrame := df atAll: rowNumbers.
+
+	self assert: actualDataFrame equals: expectedDataFrame
+]
+
+{ #category : #tests }
 DataFrameTest >> testAtAt [
 
 	self assert: (df at: 2 at: 1) equals: 'Dubai'.

--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -518,6 +518,13 @@ DataFrame >> at: aNumber transform: aBlock [
 	^ self rowAt: aNumber transform: aBlock
 ]
 
+{ #category : #accessing }
+DataFrame >> atAll: indexes [
+	"For polymorphisme with other collections."
+
+	^ self rowsAt: indexes
+]
+
 { #category : #statistics }
 DataFrame >> average [
 


### PR DESCRIPTION
…ections

This will be use to speed up the random partitioner a lot on data frames