### PR TITLE
Arithmetic operations should be possible with nils

### DIFF
--- a/src/DataFrame-Tests/DataSeriesTest.class.st
+++ b/src/DataFrame-Tests/DataSeriesTest.class.st
@@ -188,6 +188,17 @@ DataSeriesTest >> testArithmeticsDivideSeriesBySeriesSameKeysDifferentName [
 	self assert: actual equals: expected
 ]
 
+{ #category : #'as yet unclassified' }
+DataSeriesTest >> testArithmeticsDivideSeriesBySeriesWithNils [
+
+	| a b c |
+	a := #( 2 4 nil ) asDataSeries.
+	b := #( 1 nil 3 ) asDataSeries.
+	c := #( 2 nil nil ) asDataSeries.
+
+	self assert: a / b equals: c
+]
+
 { #category : #arithmetic }
 DataSeriesTest >> testArithmeticsMultiplyArrayBySeries [
 

--- a/src/DataFrame-Tests/DataSeriesTest.class.st
+++ b/src/DataFrame-Tests/DataSeriesTest.class.st
@@ -8,7 +8,7 @@ Class {
 	#category : #'DataFrame-Tests'
 }
 
-{ #category : #'tests - running' }
+{ #category : #running }
 DataSeriesTest >> setUp [
 
 	super setUp.
@@ -19,12 +19,12 @@ DataSeriesTest >> setUp [
 
 { #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsAddArrayToSeries [
-	| series array actual expected |
 
-	series := DataSeries withKeys: #(a b c) values: #(1 2 3) name: #X.
-	array := #(3 4 5).
+	| array actual expected |
+	series := DataSeries withKeys: #( a b c ) values: #( 1 2 3 ) name: #X.
+	array := #( 3 4 5 ).
 
-	expected := DataSeries withKeys: #(a b c) values: #(4 6 8) name: #X.
+	expected := DataSeries withKeys: #( a b c ) values: #( 4 6 8 ) name: #X.
 	actual := series + array.
 
 	self assert: actual equals: expected
@@ -32,12 +32,12 @@ DataSeriesTest >> testArithmeticsAddArrayToSeries [
 
 { #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsAddScalarToSeries [
-	| series scalar actual expected |
 
-	series := DataSeries withKeys: #(a b c) values: #(1 2 3) name: #X.
+	| scalar actual expected |
+	series := DataSeries withKeys: #( a b c ) values: #( 1 2 3 ) name: #X.
 	scalar := 10.
 
-	expected := DataSeries withKeys: #(a b c) values: #(11 12 13) name: #X.
+	expected := DataSeries withKeys: #( a b c ) values: #( 11 12 13 ) name: #X.
 	actual := series + scalar.
 
 	self assert: actual equals: expected
@@ -45,12 +45,12 @@ DataSeriesTest >> testArithmeticsAddScalarToSeries [
 
 { #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsAddSeriesToArray [
-	| array series actual expected |
 
-	array := #(1 2 3).
-	series := DataSeries withKeys: #(a b c) values: #(3 4 5) name: #X.
+	| array actual expected |
+	array := #( 1 2 3 ).
+	series := DataSeries withKeys: #( a b c ) values: #( 3 4 5 ) name: #X.
 
-	expected := DataSeries withKeys: #(a b c) values: #(4 6 8) name: #X.
+	expected := DataSeries withKeys: #( a b c ) values: #( 4 6 8 ) name: #X.
 	actual := array + series.
 
 	self assert: actual equals: expected
@@ -58,12 +58,12 @@ DataSeriesTest >> testArithmeticsAddSeriesToArray [
 
 { #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsAddSeriesToScalar [
-	| scalar series actual expected |
 
+	| scalar actual expected |
 	scalar := 10.
-	series := DataSeries withKeys: #(a b c) values: #(3 4 5) name: #X.
+	series := DataSeries withKeys: #( a b c ) values: #( 3 4 5 ) name: #X.
 
-	expected := DataSeries withKeys: #(a b c) values: #(13 14 15) name: #X.
+	expected := DataSeries withKeys: #( a b c ) values: #( 13 14 15 ) name: #X.
 	actual := scalar + series.
 
 	self assert: actual equals: expected

--- a/src/DataFrame-Tests/DataSeriesTest.class.st
+++ b/src/DataFrame-Tests/DataSeriesTest.class.st
@@ -8,7 +8,7 @@ Class {
 	#category : #'DataFrame-Tests'
 }
 
-{ #category : #running }
+{ #category : #'tests - running' }
 DataSeriesTest >> setUp [
 
 	super setUp.
@@ -17,7 +17,7 @@ DataSeriesTest >> setUp [
 	series := DataSeries withKeys: keyArray values: #( 3 7 6 20 8 9 8 10 15 13 16 ) name: 'ExampleSeries'
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsAddArrayToSeries [
 	| series array actual expected |
 
@@ -30,7 +30,7 @@ DataSeriesTest >> testArithmeticsAddArrayToSeries [
 	self assert: actual equals: expected
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsAddScalarToSeries [
 	| series scalar actual expected |
 
@@ -43,7 +43,7 @@ DataSeriesTest >> testArithmeticsAddScalarToSeries [
 	self assert: actual equals: expected
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsAddSeriesToArray [
 	| array series actual expected |
 
@@ -56,7 +56,7 @@ DataSeriesTest >> testArithmeticsAddSeriesToArray [
 	self assert: actual equals: expected
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsAddSeriesToScalar [
 	| scalar series actual expected |
 
@@ -69,7 +69,7 @@ DataSeriesTest >> testArithmeticsAddSeriesToScalar [
 	self assert: actual equals: expected
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsAddSeriesToSeriesDifferentKeys [
 	| firstSeries secondSeries |
 
@@ -79,7 +79,7 @@ DataSeriesTest >> testArithmeticsAddSeriesToSeriesDifferentKeys [
 	self should: [ firstSeries + secondSeries ] raise: Error
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsAddSeriesToSeriesSameKeysAndName [
 	| firstSeries secondSeries actual expected |
 
@@ -92,7 +92,7 @@ DataSeriesTest >> testArithmeticsAddSeriesToSeriesSameKeysAndName [
 	self assert: actual equals: expected
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsAddSeriesToSeriesSameKeysDifferentName [
 	| firstSeries secondSeries actual expected |
 
@@ -105,7 +105,7 @@ DataSeriesTest >> testArithmeticsAddSeriesToSeriesSameKeysDifferentName [
 	self assert: actual equals: expected
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsDivideArrayBySeries [
 
 	| array a b |
@@ -117,7 +117,7 @@ DataSeriesTest >> testArithmeticsDivideArrayBySeries [
 	self assert: array / a equals: b
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsDivideSeriesByArray [
 
 	| array a b |
@@ -129,7 +129,7 @@ DataSeriesTest >> testArithmeticsDivideSeriesByArray [
 	self assert: a / array equals: b
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsDivideSeriesByScalar [
 
 	| a b |
@@ -140,7 +140,7 @@ DataSeriesTest >> testArithmeticsDivideSeriesByScalar [
 	self assert: a / 2 equals: b
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsDivideSeriesBySeries [
 
 	| a b c |
@@ -152,7 +152,7 @@ DataSeriesTest >> testArithmeticsDivideSeriesBySeries [
 	self assert: a / b equals: c
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsDivideSeriesBySeriesDifferentKeys [
 	| firstSeries secondSeries |
 
@@ -162,7 +162,7 @@ DataSeriesTest >> testArithmeticsDivideSeriesBySeriesDifferentKeys [
 	self should: [ firstSeries / secondSeries ] raise: Error
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsDivideSeriesBySeriesSameKeysAndName [
 	| firstSeries secondSeries actual expected |
 
@@ -175,7 +175,7 @@ DataSeriesTest >> testArithmeticsDivideSeriesBySeriesSameKeysAndName [
 	self assert: actual equals: expected
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsDivideSeriesBySeriesSameKeysDifferentName [
 	| firstSeries secondSeries actual expected |
 
@@ -188,7 +188,7 @@ DataSeriesTest >> testArithmeticsDivideSeriesBySeriesSameKeysDifferentName [
 	self assert: actual equals: expected
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsDivideSeriesBySeriesWithNils [
 
 	| a b c |
@@ -199,7 +199,7 @@ DataSeriesTest >> testArithmeticsDivideSeriesBySeriesWithNils [
 	self assert: a / b equals: c
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsMultiplyArrayBySeries [
 
 	| array a b |
@@ -211,7 +211,7 @@ DataSeriesTest >> testArithmeticsMultiplyArrayBySeries [
 	self assert: array * a equals: b
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsMultiplyScalarBySeries [
 
 	| a b |
@@ -222,7 +222,7 @@ DataSeriesTest >> testArithmeticsMultiplyScalarBySeries [
 	self assert: 2 * a equals: b
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsMultiplySeriesByArray [
 
 	| array a b |
@@ -234,7 +234,7 @@ DataSeriesTest >> testArithmeticsMultiplySeriesByArray [
 	self assert: a * array equals: b
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsMultiplySeriesByScalar [
 
 	| a b |
@@ -245,7 +245,7 @@ DataSeriesTest >> testArithmeticsMultiplySeriesByScalar [
 	self assert: a * 2 equals: b
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsMultiplySeriesBySeries [
 
 	| a b c |
@@ -257,7 +257,7 @@ DataSeriesTest >> testArithmeticsMultiplySeriesBySeries [
 	self assert: a * b equals: c
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsMultiplySeriesBySeriesDifferentKeys [
 	| firstSeries secondSeries |
 
@@ -267,7 +267,7 @@ DataSeriesTest >> testArithmeticsMultiplySeriesBySeriesDifferentKeys [
 	self should: [ firstSeries * secondSeries ] raise: Error
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsMultiplySeriesBySeriesSameKeysAndName [
 	| firstSeries secondSeries actual expected |
 
@@ -280,7 +280,7 @@ DataSeriesTest >> testArithmeticsMultiplySeriesBySeriesSameKeysAndName [
 	self assert: actual equals: expected
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsMultiplySeriesBySeriesSameKeysDifferentName [
 	| firstSeries secondSeries actual expected |
 
@@ -293,7 +293,7 @@ DataSeriesTest >> testArithmeticsMultiplySeriesBySeriesSameKeysDifferentName [
 	self assert: actual equals: expected
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsSubtractArrayFromSeries [
 
 	| array a b |
@@ -305,7 +305,7 @@ DataSeriesTest >> testArithmeticsSubtractArrayFromSeries [
 	self assert: a - array equals: b
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsSubtractScalarFromSeries [
 
 	| a b |
@@ -316,7 +316,7 @@ DataSeriesTest >> testArithmeticsSubtractScalarFromSeries [
 	self assert: a - 2 equals: b
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsSubtractSeriesFromArray [
 
 	| array a b |
@@ -328,7 +328,7 @@ DataSeriesTest >> testArithmeticsSubtractSeriesFromArray [
 	self assert: array - a equals: b
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsSubtractSeriesFromScalar [
 
 	| a b |
@@ -339,7 +339,7 @@ DataSeriesTest >> testArithmeticsSubtractSeriesFromScalar [
 	self assert: 2 - a equals: b
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsSubtractSeriesFromSeries [
 
 	| a b c |
@@ -351,7 +351,7 @@ DataSeriesTest >> testArithmeticsSubtractSeriesFromSeries [
 	self assert: a - b equals: c
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsSubtractSeriesFromSeriesDifferentKeys [
 	| firstSeries secondSeries |
 
@@ -361,7 +361,7 @@ DataSeriesTest >> testArithmeticsSubtractSeriesFromSeriesDifferentKeys [
 	self should: [ firstSeries - secondSeries ] raise: Error
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsSubtractSeriesFromSeriesSameKeysAndName [
 	| firstSeries secondSeries actual expected |
 
@@ -374,7 +374,7 @@ DataSeriesTest >> testArithmeticsSubtractSeriesFromSeriesSameKeysAndName [
 	self assert: actual equals: expected
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testArithmeticsSubtractSeriesFromSeriesSameKeysDifferentName [
 	| firstSeries secondSeries actual expected |
 
@@ -387,7 +387,7 @@ DataSeriesTest >> testArithmeticsSubtractSeriesFromSeriesSameKeysDifferentName [
 	self assert: actual equals: expected
 ]
 
-{ #category : #converting }
+{ #category : #'tests - converting' }
 DataSeriesTest >> testAsDataFrame [
 	| expected actual |
 
@@ -400,7 +400,7 @@ DataSeriesTest >> testAsDataFrame [
 	self assert: actual equals: expected
 ]
 
-{ #category : #creation }
+{ #category : #'tests - creation' }
 DataSeriesTest >> testAsDataSeriesEmpty [
 
 	| dataseries expected |
@@ -411,7 +411,7 @@ DataSeriesTest >> testAsDataSeriesEmpty [
 	self assert: dataseries equals: expected
 ]
 
-{ #category : #converting }
+{ #category : #'tests - converting' }
 DataSeriesTest >> testAsDictionary [
 	| expected actual |
 
@@ -424,19 +424,19 @@ DataSeriesTest >> testAsDictionary [
 	self assert: actual equals: expected
 ]
 
-{ #category : #accessing }
+{ #category : #'tests - accessing' }
 DataSeriesTest >> testAt [
 
 	self assert: (series at: #b) equals: 7
 ]
 
-{ #category : #accessing }
+{ #category : #'tests - accessing' }
 DataSeriesTest >> testAtIndex [
 
 	self assert: (series atIndex: 2) equals: 7
 ]
 
-{ #category : #accessing }
+{ #category : #'tests - accessing' }
 DataSeriesTest >> testAtIndexPut [
 
 	| expected |
@@ -451,7 +451,7 @@ DataSeriesTest >> testAtIndexPut [
 	self assert: series equals: expected
 ]
 
-{ #category : #accessing }
+{ #category : #'tests - accessing' }
 DataSeriesTest >> testAtIndexTransform [
 
 	| expected |
@@ -466,7 +466,7 @@ DataSeriesTest >> testAtIndexTransform [
 	self assert: series equals: expected
 ]
 
-{ #category : #accessing }
+{ #category : #'tests - accessing' }
 DataSeriesTest >> testAtPut [
 
 	| expected |
@@ -481,7 +481,7 @@ DataSeriesTest >> testAtPut [
 	self assert: series equals: expected
 ]
 
-{ #category : #accessing }
+{ #category : #'tests - accessing' }
 DataSeriesTest >> testAtPutNewElement [
 
 	| expected |
@@ -496,7 +496,7 @@ DataSeriesTest >> testAtPutNewElement [
 	self assert: series equals: expected
 ]
 
-{ #category : #accessing }
+{ #category : #'tests - accessing' }
 DataSeriesTest >> testAtTransform [
 
 	| expected |
@@ -511,7 +511,7 @@ DataSeriesTest >> testAtTransform [
 	self assert: series equals: expected
 ]
 
-{ #category : #accessing }
+{ #category : #'tests - accessing' }
 DataSeriesTest >> testAtTransformIfAbsent [
 
 	| expected exceptionBlockEvaluated |
@@ -531,7 +531,7 @@ DataSeriesTest >> testAtTransformIfAbsent [
 	self assert: exceptionBlockEvaluated
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanGreaterThanEqualFromScalar [
 
 	| aSeries expected |
@@ -542,7 +542,7 @@ DataSeriesTest >> testBooleanGreaterThanEqualFromScalar [
 	self assert: 1 >= aSeries equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanGreaterThanEqualWithArray [
 
 	| aSeries expected |
@@ -553,7 +553,7 @@ DataSeriesTest >> testBooleanGreaterThanEqualWithArray [
 	self assert: aSeries >= #(1 0.1 'b') equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanGreaterThanEqualWithScalar [
 
 	| firstSeries expected |
@@ -564,7 +564,7 @@ DataSeriesTest >> testBooleanGreaterThanEqualWithScalar [
 	self assert: firstSeries >= 0.8 equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanGreaterThanEqualWithSeries [
 
 	| firstSeries secondSeries expected |
@@ -576,7 +576,7 @@ DataSeriesTest >> testBooleanGreaterThanEqualWithSeries [
 	self assert: firstSeries >= secondSeries equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanGreaterThanEqualWithSeriesDifferentKeys [
 
 	| firstSeries secondSeries |
@@ -587,7 +587,7 @@ DataSeriesTest >> testBooleanGreaterThanEqualWithSeriesDifferentKeys [
 	self should: [ firstSeries >= secondSeries ] raise: Error
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanGreaterThanEqualWithSeriesDifferentNames [
 
 	| firstSeries secondSeries expected |
@@ -599,7 +599,7 @@ DataSeriesTest >> testBooleanGreaterThanEqualWithSeriesDifferentNames [
 	self assert: firstSeries >= secondSeries equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanGreaterThanFromScalar [
 
 	| aSeries expected |
@@ -610,7 +610,7 @@ DataSeriesTest >> testBooleanGreaterThanFromScalar [
 	self assert: 1 > aSeries equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanGreaterThanWithArray [
 
 	| aSeries expected |
@@ -621,7 +621,7 @@ DataSeriesTest >> testBooleanGreaterThanWithArray [
 	self assert: aSeries > #(1 0.1 'b') equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanGreaterThanWithScalar [
 
 	| firstSeries expected |
@@ -632,7 +632,7 @@ DataSeriesTest >> testBooleanGreaterThanWithScalar [
 	self assert: firstSeries >= 0.8 equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanGreaterThanWithSeries [
 
 	| firstSeries secondSeries expected |
@@ -644,7 +644,7 @@ DataSeriesTest >> testBooleanGreaterThanWithSeries [
 	self assert: firstSeries > secondSeries equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanGreaterThanWithSeriesDifferentKeys [
 
 	| firstSeries secondSeries |
@@ -655,7 +655,7 @@ DataSeriesTest >> testBooleanGreaterThanWithSeriesDifferentKeys [
 	self should: [ firstSeries > secondSeries ] raise: Error
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanGreaterThanWithSeriesDifferentNames [
 
 	| firstSeries secondSeries expected |
@@ -667,7 +667,7 @@ DataSeriesTest >> testBooleanGreaterThanWithSeriesDifferentNames [
 	self assert: firstSeries > secondSeries equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanLessThanEqualFromScalar [
 
 	| aSeries expected |
@@ -678,7 +678,7 @@ DataSeriesTest >> testBooleanLessThanEqualFromScalar [
 	self assert: 1 <= aSeries equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanLessThanEqualWithArray [
 
 	| aSeries expected |
@@ -689,7 +689,7 @@ DataSeriesTest >> testBooleanLessThanEqualWithArray [
 	self assert: aSeries <= #(1 0.1 'b') equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanLessThanEqualWithScalar [
 
 	| firstSeries expected |
@@ -700,7 +700,7 @@ DataSeriesTest >> testBooleanLessThanEqualWithScalar [
 	self assert: firstSeries <= 0.8 equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanLessThanEqualWithSeries [
 
 	| firstSeries secondSeries expected |
@@ -712,7 +712,7 @@ DataSeriesTest >> testBooleanLessThanEqualWithSeries [
 	self assert: firstSeries <= secondSeries equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanLessThanEqualWithSeriesDifferentKeys [
 
 	| firstSeries secondSeries |
@@ -723,7 +723,7 @@ DataSeriesTest >> testBooleanLessThanEqualWithSeriesDifferentKeys [
 	self should: [ firstSeries <= secondSeries ] raise: Error
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanLessThanEqualWithSeriesDifferentNames [
 
 	| firstSeries secondSeries expected |
@@ -735,7 +735,7 @@ DataSeriesTest >> testBooleanLessThanEqualWithSeriesDifferentNames [
 	self assert: firstSeries <= secondSeries equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanLessThanFromScalar [
 
 	| aSeries expected |
@@ -746,7 +746,7 @@ DataSeriesTest >> testBooleanLessThanFromScalar [
 	self assert: 1 < aSeries equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanLessThanWithArray [
 
 	| aSeries expected |
@@ -757,7 +757,7 @@ DataSeriesTest >> testBooleanLessThanWithArray [
 	self assert: aSeries < #(1 0.1 'b') equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanLessThanWithScalar [
 
 	| firstSeries expected |
@@ -768,7 +768,7 @@ DataSeriesTest >> testBooleanLessThanWithScalar [
 	self assert: firstSeries < 0.8 equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanLessThanWithSeries [
 
 	| firstSeries secondSeries expected |
@@ -780,7 +780,7 @@ DataSeriesTest >> testBooleanLessThanWithSeries [
 	self assert: firstSeries < secondSeries equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanLessThanWithSeriesDifferentKeys [
 
 	| firstSeries secondSeries |
@@ -791,7 +791,7 @@ DataSeriesTest >> testBooleanLessThanWithSeriesDifferentKeys [
 	self should: [ firstSeries < secondSeries ] raise: Error
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanLessThanWithSeriesDifferentNames [
 
 	| firstSeries secondSeries expected |
@@ -803,7 +803,7 @@ DataSeriesTest >> testBooleanLessThanWithSeriesDifferentNames [
 	self assert: firstSeries < secondSeries equals: expected
 ]
 
-{ #category : #tests }
+{ #category : #'tests - datatypes' }
 DataSeriesTest >> testCalculateDataType [
 
 	| newSeries |
@@ -812,7 +812,7 @@ DataSeriesTest >> testCalculateDataType [
 	self assert: newSeries calculateDataType equals: UndefinedObject
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testCategoricalCanBeMadeCategorical [
 
 	| categoricalSeries |
@@ -820,7 +820,7 @@ DataSeriesTest >> testCategoricalCanBeMadeCategorical [
 	self assert: categoricalSeries makeCategorical isCategorical
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testCategoricalCanBeMadeNumerical [
 
 	| categoricalSeries |
@@ -828,7 +828,7 @@ DataSeriesTest >> testCategoricalCanBeMadeNumerical [
 	self assert: categoricalSeries makeNumerical isNumerical
 ]
 
-{ #category : #categorical }
+{ #category : #'tests - categorical' }
 DataSeriesTest >> testCategoricalCrossTabulateWith [
 
 	| series1 series2 expected |
@@ -844,7 +844,7 @@ DataSeriesTest >> testCategoricalCrossTabulateWith [
 	self assert: (series1 crossTabulateWith: series2) equals: expected
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testCategoricalIsCategorical [
 
 	| categoricalSeries |
@@ -852,7 +852,7 @@ DataSeriesTest >> testCategoricalIsCategorical [
 	self assert: categoricalSeries isCategorical
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testCategoricalIsNotNumerical [
 
 	| categoricalSeries |
@@ -860,7 +860,7 @@ DataSeriesTest >> testCategoricalIsNotNumerical [
 	self deny: categoricalSeries isNumerical
 ]
 
-{ #category : #categorical }
+{ #category : #'tests - categorical' }
 DataSeriesTest >> testCategoricalUniqueValues [
 	| aSeries expected actual |
 	aSeries := DataSeries withKeys: #(a b c d e) values: #(z y y z x).
@@ -869,7 +869,7 @@ DataSeriesTest >> testCategoricalUniqueValues [
 	self assert: actual equals: expected
 ]
 
-{ #category : #categorical }
+{ #category : #'tests - categorical' }
 DataSeriesTest >> testCategoricalValueCounts [
 	| actual expected |
 
@@ -882,7 +882,7 @@ DataSeriesTest >> testCategoricalValueCounts [
 	self assert: actual equals: expected
 ]
 
-{ #category : #categorical }
+{ #category : #'tests - categorical' }
 DataSeriesTest >> testCategoricalValueFrequencies [
 
 	| aSeries expected actual |
@@ -900,7 +900,7 @@ DataSeriesTest >> testCategoricalValueFrequencies [
 	self assert: actual equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testCloseTo [
 
 	| firstSeries secondSeries |
@@ -911,7 +911,7 @@ DataSeriesTest >> testCloseTo [
 	self assert: firstSeries closeTo: secondSeries
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testCloseToDifferentKeys [
 
 	| firstSeries secondSeries |
@@ -922,7 +922,7 @@ DataSeriesTest >> testCloseToDifferentKeys [
 	self deny: (firstSeries closeTo: secondSeries)
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testCloseToDifferentNames [
 
 	| firstSeries secondSeries |
@@ -933,7 +933,7 @@ DataSeriesTest >> testCloseToDifferentNames [
 	self deny: (firstSeries closeTo: secondSeries)
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testCloseToDifferentValues [
 
 	| firstSeries secondSeries |
@@ -944,7 +944,7 @@ DataSeriesTest >> testCloseToDifferentValues [
 	self deny: (firstSeries closeTo: secondSeries)
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testCollect [
 
 	| actual expected |
@@ -960,7 +960,7 @@ DataSeriesTest >> testCollect [
 	self assert: actual equals: expected
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testCollectWithNotNils [
 
 	| actual expected |
@@ -981,7 +981,7 @@ DataSeriesTest >> testCollectWithNotNils [
 	self assert: actual equals: expected
 ]
 
-{ #category : #copying }
+{ #category : #'tests - copying' }
 DataSeriesTest >> testCopyCanBeChanged [
 
 	| original seriesCopy expectedCopyAfterChange |
@@ -1006,7 +1006,7 @@ DataSeriesTest >> testCopyCanBeChanged [
 	self assert: seriesCopy equals: expectedCopyAfterChange
 ]
 
-{ #category : #copying }
+{ #category : #'tests - copying' }
 DataSeriesTest >> testCopyChangeDoesNotAffectOriginal [
 
 	| original seriesCopy expectedOriginalAfterChange |
@@ -1031,7 +1031,7 @@ DataSeriesTest >> testCopyChangeDoesNotAffectOriginal [
 	self assert: original equals: expectedOriginalAfterChange
 ]
 
-{ #category : #creation }
+{ #category : #'tests - creation' }
 DataSeriesTest >> testCreateDataSeriesAsDataSeries [
 
 	| dataSeries |
@@ -1043,7 +1043,7 @@ DataSeriesTest >> testCreateDataSeriesAsDataSeries [
 	self assert: dataSeries name equals: '(no name)'
 ]
 
-{ #category : #creation }
+{ #category : #'tests - creation' }
 DataSeriesTest >> testCreateDataSeriesWithKeysValues [
 
 	| values keys dataSeries |
@@ -1061,7 +1061,7 @@ DataSeriesTest >> testCreateDataSeriesWithKeysValues [
 	self assert: dataSeries name equals: '(no name)'
 ]
 
-{ #category : #creation }
+{ #category : #'tests - creation' }
 DataSeriesTest >> testCreateDataSeriesWithKeysValuesName [
 
 	| values keys name dataSeries |
@@ -1081,7 +1081,7 @@ DataSeriesTest >> testCreateDataSeriesWithKeysValuesName [
 	self assert: dataSeries name equals: name
 ]
 
-{ #category : #creation }
+{ #category : #'tests - creation' }
 DataSeriesTest >> testCreateDataSeriesWithValues [
 
 	| values dataSeries |
@@ -1095,7 +1095,7 @@ DataSeriesTest >> testCreateDataSeriesWithValues [
 	self assert: dataSeries name equals: '(no name)'
 ]
 
-{ #category : #creation }
+{ #category : #'tests - creation' }
 DataSeriesTest >> testCreateDataSeriesWithValuesName [
 
 	| values name dataSeries |
@@ -1113,7 +1113,7 @@ DataSeriesTest >> testCreateDataSeriesWithValuesName [
 	self assert: dataSeries name equals: name
 ]
 
-{ #category : #creation }
+{ #category : #'tests - creation' }
 DataSeriesTest >> testCreateEmptyDataSeries [
 
 	| dataSeries |
@@ -1125,7 +1125,7 @@ DataSeriesTest >> testCreateEmptyDataSeries [
 	self assert: dataSeries name equals: '(no name)'
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testDetect [
 
 	| expected actual |
@@ -1135,7 +1135,7 @@ DataSeriesTest >> testDetect [
 	self assert: actual equals: expected
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testDetectIfNone [
 
 	| expected actual |
@@ -1145,7 +1145,7 @@ DataSeriesTest >> testDetectIfNone [
 	self assert: actual equals: expected
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testDetectNotFound [
 
 	self
@@ -1153,7 +1153,7 @@ DataSeriesTest >> testDetectNotFound [
 		raise: NotFound
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testDo [
 
 	| sum |
@@ -1165,13 +1165,13 @@ DataSeriesTest >> testDo [
 	self assert: sum equals: 115
 ]
 
-{ #category : #accessing }
+{ #category : #'tests - accessing' }
 DataSeriesTest >> testEighth [
 
 	self assert: series eighth equals: 10
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testEquality [
 
 	| firstSeries secondSeries |
@@ -1182,25 +1182,25 @@ DataSeriesTest >> testEquality [
 	self assert: firstSeries equals: secondSeries
 ]
 
-{ #category : #accessing }
+{ #category : #'tests - accessing' }
 DataSeriesTest >> testFifth [
 
 	self assert: series fifth equals: 8
 ]
 
-{ #category : #accessing }
+{ #category : #'tests - accessing' }
 DataSeriesTest >> testFirst [
 
 	self assert: series first equals: 3
 ]
 
-{ #category : #accessing }
+{ #category : #'tests - accessing' }
 DataSeriesTest >> testFourth [
 
 	self assert: series fourth equals: 20
 ]
 
-{ #category : #grouping }
+{ #category : #'tests - grouping' }
 DataSeriesTest >> testGroupByAggregateUsing [
 	| firstSeries secondSeries expected actual |
 
@@ -1216,7 +1216,7 @@ DataSeriesTest >> testGroupByAggregateUsing [
 	self assert: actual equals: expected
 ]
 
-{ #category : #grouping }
+{ #category : #'tests - grouping' }
 DataSeriesTest >> testGroupByAggregateUsingAs [
 	| firstSeries secondSeries expected actual |
 
@@ -1232,7 +1232,7 @@ DataSeriesTest >> testGroupByAggregateUsingAs [
 	self assert: actual equals: expected
 ]
 
-{ #category : #grouping }
+{ #category : #'tests - grouping' }
 DataSeriesTest >> testGroupByAggregateUsingAsSizeMismatch [
 	| firstSeries secondSeries |
 
@@ -1244,7 +1244,7 @@ DataSeriesTest >> testGroupByAggregateUsingAsSizeMismatch [
 		raise: SizeMismatch
 ]
 
-{ #category : #grouping }
+{ #category : #'tests - grouping' }
 DataSeriesTest >> testGroupByAggregateUsingSizeMismatch [
 	| firstSeries secondSeries |
 
@@ -1256,7 +1256,7 @@ DataSeriesTest >> testGroupByAggregateUsingSizeMismatch [
 		raise: SizeMismatch
 ]
 
-{ #category : #grouping }
+{ #category : #'tests - grouping' }
 DataSeriesTest >> testGroupByBins [
 
 	| actual expected |
@@ -1265,7 +1265,7 @@ DataSeriesTest >> testGroupByBins [
 	self assert: actual equals: expected
 ]
 
-{ #category : #grouping }
+{ #category : #'tests - grouping' }
 DataSeriesTest >> testGroupByBinsLabelled [
 
 	| actual expected |
@@ -1276,7 +1276,7 @@ DataSeriesTest >> testGroupByBinsLabelled [
 	self assert: actual equals: expected
 ]
 
-{ #category : #grouping }
+{ #category : #'tests - grouping' }
 DataSeriesTest >> testGroupByBinsLabelledWithSizeProblem [
 
 	self
@@ -1287,7 +1287,7 @@ DataSeriesTest >> testGroupByBinsLabelledWithSizeProblem [
 		raise: SizeMismatch
 ]
 
-{ #category : #grouping }
+{ #category : #'tests - grouping' }
 DataSeriesTest >> testGroupByUniqueValuesAndAggregateUsing [
 
 	series := DataSeries withValues: #( Male Female Male Male Female ) name: #sex.
@@ -1295,21 +1295,21 @@ DataSeriesTest >> testGroupByUniqueValuesAndAggregateUsing [
 	self assert: (series groupByUniqueValuesAndAggregateUsing: #size) equals: (DataSeries withKeys: #( #Female #Male ) values: #( 2 3 ) name: #sex)
 ]
 
-{ #category : #'missing values' }
+{ #category : #'tests - missing values' }
 DataSeriesTest >> testHasNil [
 	| numbers |
 	numbers := #(1 2 nil 3 4) asDataSeries.
 	self assert: numbers hasNil
 ]
 
-{ #category : #'missing values' }
+{ #category : #'tests - missing values' }
 DataSeriesTest >> testHasNilFalse [
 	| numbers |
 	numbers := #(1 2 3 4) asDataSeries.
 	self deny: numbers hasNil
 ]
 
-{ #category : #'head/tail' }
+{ #category : #'tests - head/tail' }
 DataSeriesTest >> testHead [
 	| expected actual |
 
@@ -1322,7 +1322,7 @@ DataSeriesTest >> testHead [
 	self assert: actual equals: expected
 ]
 
-{ #category : #'head/tail' }
+{ #category : #'tests - head/tail' }
 DataSeriesTest >> testHeadN [
 	| expected actual |
 
@@ -1335,7 +1335,7 @@ DataSeriesTest >> testHeadN [
 	self assert: actual equals: expected
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testInequality [
 
 	| a b |
@@ -1349,7 +1349,7 @@ DataSeriesTest >> testInequality [
 	self assert: (a ~= b)
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testInequalityDifferentKeys [
 
 	| firstSeries secondSeries |
@@ -1360,7 +1360,7 @@ DataSeriesTest >> testInequalityDifferentKeys [
 	self assert: (firstSeries ~= secondSeries)
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testInequalityDifferentNames [
 
 	| firstSeries secondSeries |
@@ -1371,7 +1371,7 @@ DataSeriesTest >> testInequalityDifferentNames [
 	self assert: (firstSeries ~= secondSeries)
 ]
 
-{ #category : #comparing }
+{ #category : #'tests - comparing' }
 DataSeriesTest >> testInequalityDifferentValues [
 
 	| firstSeries secondSeries |
@@ -1382,7 +1382,7 @@ DataSeriesTest >> testInequalityDifferentValues [
 	self assert: (firstSeries ~= secondSeries)
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testInjectInto [
 
 	| expected actual |
@@ -1392,13 +1392,13 @@ DataSeriesTest >> testInjectInto [
 	self assert: actual equals: expected
 ]
 
-{ #category : #accessing }
+{ #category : #'tests - accessing' }
 DataSeriesTest >> testLast [
 
 	self assert: series last equals: 16
 ]
 
-{ #category : #'math functions' }
+{ #category : #'tests - math functions' }
 DataSeriesTest >> testMathAbs [
 
 	| a b |
@@ -1409,7 +1409,7 @@ DataSeriesTest >> testMathAbs [
 	self assert: a abs closeTo: b
 ]
 
-{ #category : #'math functions' }
+{ #category : #'tests - math functions' }
 DataSeriesTest >> testMathCorrelationWith [
 	| age income correlationCoefficient |
 
@@ -1420,7 +1420,7 @@ DataSeriesTest >> testMathCorrelationWith [
 	self assert: correlationCoefficient closeTo: 0.99380799
 ]
 
-{ #category : #'math functions' }
+{ #category : #'tests - math functions' }
 DataSeriesTest >> testMathCos [
 
 	| a b pi |
@@ -1432,7 +1432,7 @@ DataSeriesTest >> testMathCos [
 	self assert: a cos closeTo: b
 ]
 
-{ #category : #'math functions' }
+{ #category : #'tests - math functions' }
 DataSeriesTest >> testMathExp [
 
 	| a b |
@@ -1443,7 +1443,7 @@ DataSeriesTest >> testMathExp [
 	self assert: a exp closeTo: b
 ]
 
-{ #category : #'math functions' }
+{ #category : #'tests - math functions' }
 DataSeriesTest >> testMathLn [
 
 	| a b |
@@ -1454,7 +1454,7 @@ DataSeriesTest >> testMathLn [
 	self assert: a ln closeTo: b
 ]
 
-{ #category : #'math functions' }
+{ #category : #'tests - math functions' }
 DataSeriesTest >> testMathLog [
 
 	| a b |
@@ -1465,7 +1465,7 @@ DataSeriesTest >> testMathLog [
 	self assert: a log closeTo: b
 ]
 
-{ #category : #'math functions' }
+{ #category : #'tests - math functions' }
 DataSeriesTest >> testMathLog2 [
 
 	| a b |
@@ -1476,7 +1476,7 @@ DataSeriesTest >> testMathLog2 [
 	self assert: (a log: 2) closeTo: b
 ]
 
-{ #category : #'math functions' }
+{ #category : #'tests - math functions' }
 DataSeriesTest >> testMathPowerScalar [
 
 	| a b |
@@ -1487,7 +1487,7 @@ DataSeriesTest >> testMathPowerScalar [
 	self assert: a ** 2 equals: b
 ]
 
-{ #category : #'math functions' }
+{ #category : #'tests - math functions' }
 DataSeriesTest >> testMathSin [
 
 	| a b pi |
@@ -1499,7 +1499,7 @@ DataSeriesTest >> testMathSin [
 	self assert: a sin closeTo: b
 ]
 
-{ #category : #'math functions' }
+{ #category : #'tests - math functions' }
 DataSeriesTest >> testMathSqrt [
 
 	| a b |
@@ -1510,7 +1510,7 @@ DataSeriesTest >> testMathSqrt [
 	self assert: a sqrt closeTo: b
 ]
 
-{ #category : #'math functions' }
+{ #category : #'tests - math functions' }
 DataSeriesTest >> testMathTan [
 
 	| a b |
@@ -1521,7 +1521,7 @@ DataSeriesTest >> testMathTan [
 	self assert: a tan closeTo: b
 ]
 
-{ #category : #creation }
+{ #category : #'tests - creation' }
 DataSeriesTest >> testNewFrom [
 
 	| dataseries |
@@ -1532,13 +1532,13 @@ DataSeriesTest >> testNewFrom [
 	self assert: dataseries equals: series
 ]
 
-{ #category : #accessing }
+{ #category : #'tests - accessing' }
 DataSeriesTest >> testNinth [
 
 	self assert: series ninth equals: 15
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testNumericalCanBeMadeCategorical [
 
 	| numericalSeries |
@@ -1546,7 +1546,7 @@ DataSeriesTest >> testNumericalCanBeMadeCategorical [
 	self assert: numericalSeries makeCategorical isCategorical
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testNumericalCanBeMadeNumerical [
 
 	| numericalSeries |
@@ -1554,7 +1554,7 @@ DataSeriesTest >> testNumericalCanBeMadeNumerical [
 	self assert: numericalSeries makeNumerical isNumerical
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testNumericalIsNotCategorical [
 
 	| numericalSeries |
@@ -1562,7 +1562,7 @@ DataSeriesTest >> testNumericalIsNotCategorical [
 	self deny: numericalSeries isCategorical
 ]
 
-{ #category : #arithmetic }
+{ #category : #'tests - arithmetic' }
 DataSeriesTest >> testNumericalIsNumerical [
 
 	| numericalSeries |
@@ -1570,7 +1570,7 @@ DataSeriesTest >> testNumericalIsNumerical [
 	self assert: numericalSeries isNumerical
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testReject [
 
 	| expected actual |
@@ -1584,7 +1584,7 @@ DataSeriesTest >> testReject [
 	self assert: actual equals: expected
 ]
 
-{ #category : #removing }
+{ #category : #'tests - removing' }
 DataSeriesTest >> testRemoveAt [
 
 	| expected |
@@ -1599,7 +1599,7 @@ DataSeriesTest >> testRemoveAt [
 	self assert: series equals: expected
 ]
 
-{ #category : #removing }
+{ #category : #'tests - removing' }
 DataSeriesTest >> testRemoveAtIndex [
 
 	| expected |
@@ -1614,7 +1614,7 @@ DataSeriesTest >> testRemoveAtIndex [
 	self assert: series equals: expected
 ]
 
-{ #category : #removing }
+{ #category : #'tests - removing' }
 DataSeriesTest >> testRemoveNils [
 
 	| expected |
@@ -1625,7 +1625,7 @@ DataSeriesTest >> testRemoveNils [
 	self assert: series removeNils equals: expected
 ]
 
-{ #category : #removing }
+{ #category : #'tests - removing' }
 DataSeriesTest >> testRemoveNilsOnNamedSeries [
 
 	| expected |
@@ -1636,7 +1636,7 @@ DataSeriesTest >> testRemoveNilsOnNamedSeries [
 	self assert: series removeNils equals: expected
 ]
 
-{ #category : #'missing values' }
+{ #category : #'tests - missing values' }
 DataSeriesTest >> testReplaceNilsWith [
 
 	| expected |
@@ -1653,7 +1653,7 @@ DataSeriesTest >> testReplaceNilsWith [
 	self assert: (series replaceNilsWith: 0.0) equals: expected
 ]
 
-{ #category : #'missing values' }
+{ #category : #'tests - missing values' }
 DataSeriesTest >> testReplaceNilsWithAverage [
 
 	| expected |
@@ -1670,7 +1670,7 @@ DataSeriesTest >> testReplaceNilsWithAverage [
 	self assert: series replaceNilsWithAverage equals: expected
 ]
 
-{ #category : #'missing values' }
+{ #category : #'tests - missing values' }
 DataSeriesTest >> testReplaceNilsWithFloat [
 
 	| expected |
@@ -1687,7 +1687,7 @@ DataSeriesTest >> testReplaceNilsWithFloat [
 	self assert: (series replaceNilsWith: 3.14) equals: expected
 ]
 
-{ #category : #'missing values' }
+{ #category : #'tests - missing values' }
 DataSeriesTest >> testReplaceNilsWithMedian [
 
 	| expected |
@@ -1704,7 +1704,7 @@ DataSeriesTest >> testReplaceNilsWithMedian [
 	self assert: series replaceNilsWithMedian equals: expected
 ]
 
-{ #category : #'missing values' }
+{ #category : #'tests - missing values' }
 DataSeriesTest >> testReplaceNilsWithMode [
 
 	| expected |
@@ -1721,7 +1721,7 @@ DataSeriesTest >> testReplaceNilsWithMode [
 	self assert: series replaceNilsWithMode equals: expected
 ]
 
-{ #category : #'missing values' }
+{ #category : #'tests - missing values' }
 DataSeriesTest >> testReplaceNilsWithPreviousValue [
 
 	| sampleSeries expected |
@@ -1738,7 +1738,7 @@ DataSeriesTest >> testReplaceNilsWithPreviousValue [
 		equals: expected
 ]
 
-{ #category : #'missing values' }
+{ #category : #'tests - missing values' }
 DataSeriesTest >> testReplaceNilsWithString [
 
 	| expected |
@@ -1755,7 +1755,7 @@ DataSeriesTest >> testReplaceNilsWithString [
 	self assert: (series replaceNilsWith: 'abc') equals: expected
 ]
 
-{ #category : #'missing values' }
+{ #category : #'tests - missing values' }
 DataSeriesTest >> testReplaceNilsWithZeros [
 
 	| expected |
@@ -1772,13 +1772,13 @@ DataSeriesTest >> testReplaceNilsWithZeros [
 	self assert: (series replaceNilsWithZeros) equals: expected
 ]
 
-{ #category : #accessing }
+{ #category : #'tests - accessing' }
 DataSeriesTest >> testSecond [
 
 	self assert: series second equals: 7
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testSelect [
 
 	| expected actual |
@@ -1792,19 +1792,19 @@ DataSeriesTest >> testSelect [
 	self assert: actual equals: expected
 ]
 
-{ #category : #accessing }
+{ #category : #'tests - accessing' }
 DataSeriesTest >> testSeventh [
 
 	self assert: series seventh equals: 8
 ]
 
-{ #category : #accessing }
+{ #category : #'tests - accessing' }
 DataSeriesTest >> testSixth [
 
 	self assert: series sixth equals: 9
 ]
 
-{ #category : #sorting }
+{ #category : #'tests - sorting' }
 DataSeriesTest >> testSort [
 	| expected |
 
@@ -1817,7 +1817,7 @@ DataSeriesTest >> testSort [
 	self assert: series equals: expected
 ]
 
-{ #category : #sorting }
+{ #category : #'tests - sorting' }
 DataSeriesTest >> testSortBlock [
 	| expected |
 
@@ -1830,7 +1830,7 @@ DataSeriesTest >> testSortBlock [
 	self assert: series equals: expected
 ]
 
-{ #category : #sorting }
+{ #category : #'tests - sorting' }
 DataSeriesTest >> testSortDescending [
 	| expected |
 
@@ -1843,7 +1843,7 @@ DataSeriesTest >> testSortDescending [
 	self assert: series equals: expected
 ]
 
-{ #category : #sorting }
+{ #category : #'tests - sorting' }
 DataSeriesTest >> testSorted [
 	| expected actual |
 
@@ -1856,7 +1856,7 @@ DataSeriesTest >> testSorted [
 	self assert: actual equals: expected
 ]
 
-{ #category : #sorting }
+{ #category : #'tests - sorting' }
 DataSeriesTest >> testSortedBlock [
 	| expected actual |
 
@@ -1869,7 +1869,7 @@ DataSeriesTest >> testSortedBlock [
 	self assert: actual equals: expected
 ]
 
-{ #category : #sorting }
+{ #category : #'tests - sorting' }
 DataSeriesTest >> testSortedBlockDoesNotChangeTheReceiver [
 	| expected |
 
@@ -1882,7 +1882,7 @@ DataSeriesTest >> testSortedBlockDoesNotChangeTheReceiver [
 	self assert: series equals: expected
 ]
 
-{ #category : #sorting }
+{ #category : #'tests - sorting' }
 DataSeriesTest >> testSortedDescending [
 	| expected actual |
 
@@ -1895,7 +1895,7 @@ DataSeriesTest >> testSortedDescending [
 	self assert: actual equals: expected
 ]
 
-{ #category : #sorting }
+{ #category : #'tests - sorting' }
 DataSeriesTest >> testSortedDescendingDoesNotChangeTheReceiver [
 	| expected |
 
@@ -1908,7 +1908,7 @@ DataSeriesTest >> testSortedDescendingDoesNotChangeTheReceiver [
 	self assert: series equals: expected
 ]
 
-{ #category : #sorting }
+{ #category : #'tests - sorting' }
 DataSeriesTest >> testSortedDoesNotChangeTheReceiver [
 	| expected |
 
@@ -1921,13 +1921,13 @@ DataSeriesTest >> testSortedDoesNotChangeTheReceiver [
 	self assert: series equals: expected
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsAverage [
 
 	self assert: series average equals: (115/11)
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsCumulativeSum [
 
 	| seriesWithNils expected |
@@ -1945,55 +1945,55 @@ DataSeriesTest >> testStatsCumulativeSum [
 	self assert: seriesWithNils cumulativeSum equals: expected
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsFirstQuartile [
 
 	self assert: series firstQuartile equals: 7
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsFourthQuartile [
 
 	self assert: series fourthQuartile equals: 20
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsFourthQuartileEqualsMax [
 
 	self assert: series fourthQuartile equals: series max
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsInterquartileRange [
 
 	self assert: series interquartileRange equals: 8
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsMax [
 
 	self assert: series max equals: 20
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsMedian [
 
 	self assert: series median equals: 9
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsMin [
 
 	self assert: series min equals: 3
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsMode [
 
 	self assert: series mode equals: 8
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsQuantile [
 
 	self assert: (series quantile: 0) equals: 3.
@@ -2004,7 +2004,7 @@ DataSeriesTest >> testStatsQuantile [
 	self assert: (series quantile: 100) equals: 20
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsQuantileDoesNotModifyTheSeries [
 
 	| copy |
@@ -2013,7 +2013,7 @@ DataSeriesTest >> testStatsQuantileDoesNotModifyTheSeries [
 	self assert: series equals: copy
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsQuartile [
 
 	self assert: (series quartile: 0) equals: 3.
@@ -2023,7 +2023,7 @@ DataSeriesTest >> testStatsQuartile [
 	self assert: (series quartile: 4) equals: 20
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsQuartileWithNil [
 	series atIndex: 2 put: nil.
 	self assert: (series quartile: 0) equals: 3.
@@ -2033,31 +2033,31 @@ DataSeriesTest >> testStatsQuartileWithNil [
 	self assert: (series quartile: 4) equals: 20
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsRange [
 
 	self assert: series range equals: 17
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsSecondQuartile [
 
 	self assert: series secondQuartile equals: 9
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsSecondQuartileEqualsMedian [
 
 	self assert: series secondQuartile equals: series median
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsStdev [
 
 	self assert: series stdev closeTo: 5.00727
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsSummary [
 	| expected actual |
 
@@ -2071,31 +2071,31 @@ DataSeriesTest >> testStatsSummary [
 	self assert: actual equals: expected
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsThirdQuartile [
 
 	self assert: series thirdQuartile equals: 15
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsVariance [
 
 	self assert: series variance closeTo: 25.07273
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsZerothQuartile [
 
 	self assert: series zerothQuartile equals: 3
 ]
 
-{ #category : #statistics }
+{ #category : #'tests - statistics' }
 DataSeriesTest >> testStatsZerothQuartileEqualsMin [
 
 	self assert: series zerothQuartile equals: series min
 ]
 
-{ #category : #'head/tail' }
+{ #category : #'tests - head/tail' }
 DataSeriesTest >> testTail [
 	| expected actual |
 
@@ -2108,7 +2108,7 @@ DataSeriesTest >> testTail [
 	self assert: actual equals: expected
 ]
 
-{ #category : #'head/tail' }
+{ #category : #'tests - head/tail' }
 DataSeriesTest >> testTailN [
 	| expected actual |
 
@@ -2121,13 +2121,13 @@ DataSeriesTest >> testTailN [
 	self assert: actual equals: expected
 ]
 
-{ #category : #accessing }
+{ #category : #'tests - accessing' }
 DataSeriesTest >> testThird [
 
 	self assert: series third equals: 6
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testWithIndexCollect [
 
 	| actual expected |
@@ -2143,7 +2143,7 @@ DataSeriesTest >> testWithIndexCollect [
 	self assert: actual equals: expected
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testWithIndexDetect [
 
 	| expected actual |
@@ -2153,7 +2153,7 @@ DataSeriesTest >> testWithIndexDetect [
 	self assert: actual equals: expected
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testWithIndexDetectIfNone [
 
 	| expected actual |
@@ -2163,7 +2163,7 @@ DataSeriesTest >> testWithIndexDetectIfNone [
 	self assert: actual equals: expected
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testWithIndexDetectNotFound [
 
 	self
@@ -2171,7 +2171,7 @@ DataSeriesTest >> testWithIndexDetectNotFound [
 		raise: NotFound
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testWithIndexDo [
 
 	| sum |
@@ -2183,7 +2183,7 @@ DataSeriesTest >> testWithIndexDo [
 	self assert: sum equals: (108173/4620)
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testWithIndexReject [
 
 	| expected actual |
@@ -2197,7 +2197,7 @@ DataSeriesTest >> testWithIndexReject [
 	self assert: actual equals: expected
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testWithIndexSelect [
 
 	| expected actual |
@@ -2211,7 +2211,7 @@ DataSeriesTest >> testWithIndexSelect [
 	self assert: actual equals: expected
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testWithKeyCollect [
 
 	| actual expected |
@@ -2227,7 +2227,7 @@ DataSeriesTest >> testWithKeyCollect [
 	self assert: actual equals: expected
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testWithKeyDetect [
 
 	| expected actual |
@@ -2237,7 +2237,7 @@ DataSeriesTest >> testWithKeyDetect [
 	self assert: actual equals: expected
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testWithKeyDetectIfNone [
 
 	| expected actual |
@@ -2247,7 +2247,7 @@ DataSeriesTest >> testWithKeyDetectIfNone [
 	self assert: actual equals: expected
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testWithKeyDetectNotFound [
 
 	self
@@ -2255,7 +2255,7 @@ DataSeriesTest >> testWithKeyDetectNotFound [
 		raise: NotFound
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testWithKeyDo [
 
 	| sum |
@@ -2267,7 +2267,7 @@ DataSeriesTest >> testWithKeyDo [
 	self assert: sum equals: (108173/4620)
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testWithKeyReject [
 
 	| expected actual |
@@ -2281,7 +2281,7 @@ DataSeriesTest >> testWithKeyReject [
 	self assert: actual equals: expected
 ]
 
-{ #category : #enumerating }
+{ #category : #'tests - enumerating' }
 DataSeriesTest >> testWithKeySelect [
 
 	| expected actual |

--- a/src/DataFrame/DataSeries.class.st
+++ b/src/DataFrame/DataSeries.class.st
@@ -92,10 +92,13 @@ DataSeries >> adaptToCollection: rcvr andSend: selector [
 	"If I am involved in arithmetic with another Collection, return a Collection of
 	the results of each element combined with the scalar in that expression."
 
-	(rcvr isSequenceable and: [ self isSequenceable ]) ifFalse:
-		[self error: 'Only sequenceable collections may be combined arithmetically'].
-	^ rcvr withSeries: self collect:
-		[:rcvrElement :myElement | rcvrElement perform: selector with: myElement]
+	(rcvr isSequenceable and: [ self isSequenceable ]) ifFalse: [ self error: 'Only sequenceable collections may be combined arithmetically' ].
+
+
+	^ rcvr withSeries: self collect: [ :rcvrElement :myElement |
+		  (rcvrElement isNil or: [ myElement isNil ])
+			  ifTrue: [ nil ]
+			  ifFalse: [ rcvrElement perform: selector with: myElement ] ]
 ]
 
 { #category : #converting }

--- a/src/DataFrame/DataSeries.class.st
+++ b/src/DataFrame/DataSeries.class.st
@@ -197,13 +197,13 @@ DataSeries >> collectWithNotNils: aBlock [
 	^ self collect: [ :each | each ifNotNil: [ aBlock value: each ] ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'math functions' }
 DataSeries >> correlationWith: otherSeries [
 	"Calculate the Pearson correlation coefficient between self and the other series"
 	^ self correlationWith: otherSeries using: DataPearsonCorrelationMethod
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'math functions' }
 DataSeries >> correlationWith: otherSeries using: aCorrelationCoefficient [
 	"Calculate the correlation coefficient between self and the other series using the given method"
 	^ aCorrelationCoefficient between: self and: otherSeries


### PR DESCRIPTION
Allow arithmetic operations with nils in data series

If a nil is present, we will keep a nil in the result.

+ Some cleanings