### PR TITLE
Fix various bugs

### DIFF
--- a/src/DataFrame-Math/DataPearsonCorrelationMethod.class.st
+++ b/src/DataFrame-Math/DataPearsonCorrelationMethod.class.st
@@ -11,8 +11,8 @@ DataPearsonCorrelationMethod class >> between: x and: y [
 	| xDeviation yDeviation |
 	x size = y size ifFalse: [ SizeMismatch signal: 'Correlation can not be calculated for two series of different size' ].
 
-	xDeviation := (x values replaceAll: nil with: 0) - (x sum / x size).
-	yDeviation := (y values replaceAll: nil with: 0) - (y sum / y size).
+	xDeviation := (x values replaceAll: nil with: 0) - x average.
+	yDeviation := (y values replaceAll: nil with: 0) - y average.
 
 	^ (xDeviation * yDeviation) sum / ((xDeviation ** 2) sum * (yDeviation ** 2) sum) sqrt
 ]

--- a/src/DataFrame-Math/DataPearsonCorrelationMethod.class.st
+++ b/src/DataFrame-Math/DataPearsonCorrelationMethod.class.st
@@ -11,8 +11,8 @@ DataPearsonCorrelationMethod class >> between: x and: y [
 	| xDeviation yDeviation |
 	x size = y size ifFalse: [ SizeMismatch signal: 'Correlation can not be calculated for two series of different size' ].
 
-	xDeviation := (x values replaceAll: nil with: 0) - x average.
-	yDeviation := (y values replaceAll: nil with: 0) - y average.
+	xDeviation := (x values replaceAll: nil with: 0) - (x sum / x size).
+	yDeviation := (y values replaceAll: nil with: 0) - (y sum / y size).
 
 	^ (xDeviation * yDeviation) sum / ((xDeviation ** 2) sum * (yDeviation ** 2) sum) sqrt
 ]

--- a/src/DataFrame-Math/DataPearsonCorrelationMethod.class.st
+++ b/src/DataFrame-Math/DataPearsonCorrelationMethod.class.st
@@ -9,12 +9,10 @@ DataPearsonCorrelationMethod class >> between: x and: y [
 	"Calcualte the Pearson correlation coefficient between two data series"
 
 	| xDeviation yDeviation |
+	x size = y size ifFalse: [ SizeMismatch signal: 'Correlation can not be calculated for two series of different size' ].
 
-	x size = y size ifFalse: [
-		SizeMismatch signal: 'Correlation can not be calculated for two series of different size' ].
-
-	xDeviation := x - x average.
-	yDeviation := y - y average.
+	xDeviation := x replaceNilsWithZeros - x average.
+	yDeviation := y replaceNilsWithZeros - y average.
 
 	^ (xDeviation * yDeviation) sum / ((xDeviation ** 2) sum * (yDeviation ** 2) sum) sqrt
 ]

--- a/src/DataFrame-Math/DataPearsonCorrelationMethod.class.st
+++ b/src/DataFrame-Math/DataPearsonCorrelationMethod.class.st
@@ -11,8 +11,8 @@ DataPearsonCorrelationMethod class >> between: x and: y [
 	| xDeviation yDeviation |
 	x size = y size ifFalse: [ SizeMismatch signal: 'Correlation can not be calculated for two series of different size' ].
 
-	xDeviation := x replaceNilsWithZeros - x average.
-	yDeviation := y replaceNilsWithZeros - y average.
+	xDeviation := (x values replaceAll: nil with: 0) - x average.
+	yDeviation := (y values replaceAll: nil with: 0) - y average.
 
 	^ (xDeviation * yDeviation) sum / ((xDeviation ** 2) sum * (yDeviation ** 2) sum) sqrt
 ]

--- a/src/DataFrame-Tests/DataFrameStatsTest.class.st
+++ b/src/DataFrame-Tests/DataFrameStatsTest.class.st
@@ -37,28 +37,36 @@ DataFrameStatsTest >> testCorrelationMatrix [
 
 	| expectedCorrelationMatrix actualCorrelationMatrix |
 	expectedCorrelationMatrix := DataFrame withRows:
-		                             #( #( 1 0.311398 0.538922 0.454601 )
-		                                #( 0.311398 1 -0.321281 -0.308023 )
-		                                #( 0.538922 -0.321281 1 0.982956 )
-		                                #( 0.454601 -0.308023 0.982956
-		                                   1 ) ).
-	expectedCorrelationMatrix columnNames:
-		#( sepalLength sepalWidth petalLength petalWidth ).
-	expectedCorrelationMatrix rowNames:
-		#( sepalLength sepalWidth petalLength petalWidth ).
+		                             #( #( 1 0.311398 0.538922 0.454601 ) #( 0.311398 1 -0.321281 -0.308023 ) #( 0.538922 -0.321281 1 0.982956 )
+		                                #( 0.454601 -0.308023 0.982956 1 ) ).
+	expectedCorrelationMatrix columnNames: #( sepalLength sepalWidth petalLength petalWidth ).
+	expectedCorrelationMatrix rowNames: #( sepalLength sepalWidth petalLength petalWidth ).
 	actualCorrelationMatrix := df correlationMatrix.
-	self
-		assert: actualCorrelationMatrix rowNames
-		equals: expectedCorrelationMatrix rowNames.
-	self
-		assert: actualCorrelationMatrix columnNames
-		equals: expectedCorrelationMatrix columnNames.
+	self assert: actualCorrelationMatrix rowNames equals: expectedCorrelationMatrix rowNames.
+	self assert: actualCorrelationMatrix columnNames equals: expectedCorrelationMatrix columnNames.
 
 	1 to: actualCorrelationMatrix numberOfColumns do: [ :j |
-		1 to: actualCorrelationMatrix numberOfRows do: [ :i |
-			self
-				assert: (actualCorrelationMatrix at: i at: j)
-				closeTo: (expectedCorrelationMatrix at: i at: j) ] ]
+		1 to: actualCorrelationMatrix numberOfRows do: [ :i | self assert: (actualCorrelationMatrix at: i at: j) closeTo: (expectedCorrelationMatrix at: i at: j) ] ]
+]
+
+{ #category : #tests }
+DataFrameStatsTest >> testCorrelationMatrixWithNils [
+
+	| expectedCorrelationMatrix actualCorrelationMatrix |
+	df := DataFrame withRows: #( #( 1 1 ) #( 2 nil ) #( nil 3 ) #( 4 4 ) ).
+	df columnNames: #( dogs cats ).
+
+	expectedCorrelationMatrix := DataFrame withRows: #( #( 1 0.3207134902949093 ) #( 0.3207134902949093 1 ) ).
+	expectedCorrelationMatrix columnNames: #( dogs cats ).
+	expectedCorrelationMatrix rowNames: #( dogs cats ).
+
+	actualCorrelationMatrix := df correlationMatrix.
+
+	self assert: actualCorrelationMatrix rowNames equals: expectedCorrelationMatrix rowNames.
+	self assert: actualCorrelationMatrix columnNames equals: expectedCorrelationMatrix columnNames.
+
+	1 to: actualCorrelationMatrix numberOfColumns do: [ :j |
+		1 to: actualCorrelationMatrix numberOfRows do: [ :i | self assert: (actualCorrelationMatrix at: i at: j) closeTo: (expectedCorrelationMatrix at: i at: j) ] ]
 ]
 
 { #category : #tests }

--- a/src/DataFrame-Tests/DataFrameStatsTest.class.st
+++ b/src/DataFrame-Tests/DataFrameStatsTest.class.st
@@ -33,6 +33,23 @@ DataFrameStatsTest >> testAverage [
 ]
 
 { #category : #tests }
+DataFrameStatsTest >> testAverageWithNils [
+
+	| expected actual |
+	df := DataFrame withRows: #( #( 1 1 ) #( 2 nil ) #( nil 3 ) #( 4 4 ) ).
+	df columnNames: #( dogs cats ).
+
+	expected := {
+		            (7 / 3).
+		            (8 / 3) } asDataSeries.
+	expected name: #average.
+	expected keys: df columnNames.
+
+	actual := df average.
+	self assert: actual closeTo: expected
+]
+
+{ #category : #tests }
 DataFrameStatsTest >> testCorrelationMatrix [
 
 	| expectedCorrelationMatrix actualCorrelationMatrix |

--- a/src/DataFrame-Tests/DataFrameStatsTest.class.st
+++ b/src/DataFrame-Tests/DataFrameStatsTest.class.st
@@ -73,7 +73,7 @@ DataFrameStatsTest >> testCorrelationMatrixWithNils [
 	df := DataFrame withRows: #( #( 1 1 ) #( 2 nil ) #( nil 3 ) #( 4 4 ) ).
 	df columnNames: #( dogs cats ).
 
-	expectedCorrelationMatrix := DataFrame withRows: #( #( 1 0.3207134902949093 ) #( 0.3207134902949093 1 ) ).
+	expectedCorrelationMatrix := DataFrame withRows: #( #( 1 0.4174555390689118 ) #( 0.4174555390689118 1 ) ).
 	expectedCorrelationMatrix columnNames: #( dogs cats ).
 	expectedCorrelationMatrix rowNames: #( dogs cats ).
 

--- a/src/DataFrame-Tests/DataFrameTest.class.st
+++ b/src/DataFrame-Tests/DataFrameTest.class.st
@@ -899,6 +899,33 @@ DataFrameTest >> testColumnsSubset [
 ]
 
 { #category : #tests }
+DataFrameTest >> testCopy [
+
+	| copy |
+	copy := df copy.
+
+	self assert: copy equals: df.
+	self deny: copy identicalTo: df.
+
+	df addRow: #( 'Paris' 7 false ) named: 'D'.
+
+	self assert: df size equals: 4.
+	self assert: copy size equals: 3
+]
+
+{ #category : #tests }
+DataFrameTest >> testCopy2 [
+
+	| copy |
+	copy := df copy.
+
+	df addColumn: #( false true true ) named: 'Like it'.
+
+	self assert: df numberOfColumns equals: 4.
+	self assert: copy numberOfColumns equals: 3
+]
+
+{ #category : #tests }
 DataFrameTest >> testCreateDataFrameWith3ColumnsAndNoRows [
 	| dataFrame |
 	dataFrame := DataFrame new: 0@3.

--- a/src/DataFrame-Tests/DataSeriesTest.class.st
+++ b/src/DataFrame-Tests/DataSeriesTest.class.st
@@ -1392,6 +1392,19 @@ DataSeriesTest >> testInjectInto [
 	self assert: actual equals: expected
 ]
 
+{ #category : #'tests - testing' }
+DataSeriesTest >> testIsNumerical [
+
+	self assert: #( 1 2 3 ) asDataSeries isNumerical.
+	self deny: #( 1 2 '3' ) asDataSeries isNumerical
+]
+
+{ #category : #'tests - testing' }
+DataSeriesTest >> testIsNumericalWithNils [
+
+	self assert: #( 1 nil 3 ) asDataSeries isNumerical
+]
+
 { #category : #'tests - accessing' }
 DataSeriesTest >> testLast [
 

--- a/src/DataFrame-Tests/DataSeriesTest.class.st
+++ b/src/DataFrame-Tests/DataSeriesTest.class.st
@@ -531,6 +531,18 @@ DataSeriesTest >> testAtTransformIfAbsent [
 	self assert: exceptionBlockEvaluated
 ]
 
+{ #category : #'tests - arithmetic' }
+DataSeriesTest >> testAverage [
+
+	self assert: #( 1 2 3 4 ) asDataSeries average equals: 5 / 2
+]
+
+{ #category : #'tests - arithmetic' }
+DataSeriesTest >> testAverageWithNils [
+
+	self assert: #( 2 nil 4 ) asDataSeries average equals: 3
+]
+
 { #category : #'tests - comparing' }
 DataSeriesTest >> testBooleanGreaterThanEqualFromScalar [
 

--- a/src/DataFrame-Tests/DataSeriesTest.class.st
+++ b/src/DataFrame-Tests/DataSeriesTest.class.st
@@ -993,6 +993,21 @@ DataSeriesTest >> testCollectWithNotNils [
 	self assert: actual equals: expected
 ]
 
+{ #category : #running }
+DataSeriesTest >> testCopy [
+
+	| copy |
+	copy := series copy.
+
+	self assert: copy equals: series.
+	self deny: copy identicalTo: series.
+
+	series add: $l -> 30.
+
+	self assert: series size equals: 12.
+	self assert: copy size equals: 11
+]
+
 { #category : #'tests - copying' }
 DataSeriesTest >> testCopyCanBeChanged [
 

--- a/src/DataFrame-Tests/DataSeriesTest.class.st
+++ b/src/DataFrame-Tests/DataSeriesTest.class.st
@@ -2108,6 +2108,19 @@ DataSeriesTest >> testStatsZerothQuartileEqualsMin [
 	self assert: series zerothQuartile equals: series min
 ]
 
+{ #category : #'tests - arithmetic' }
+DataSeriesTest >> testSum [
+
+	self assert: #( 1 2 3 4 ) asDataSeries sum equals: 10
+]
+
+{ #category : #'tests - arithmetic' }
+DataSeriesTest >> testSumWithNils [
+
+	self assert: #( 1 2 nil 4 ) asDataSeries sum equals: 7.
+	self assert: #( nil nil nil ) asDataSeries sum equals: 0
+]
+
 { #category : #'tests - head/tail' }
 DataSeriesTest >> testTail [
 	| expected actual |

--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -1412,6 +1412,16 @@ DataFrame >> outerJoin: aDataFrame onLeft: leftColumn onRight: rightColumn [
 	^ outputDf
 ]
 
+{ #category : #copying }
+DataFrame >> postCopy [
+
+	super postCopy.
+	contents := contents copy.
+	rowNames := rowNames copy.
+	columnNames := columnNames copy.
+	dataTypes := dataTypes copy
+]
+
 { #category : #printing }
 DataFrame >> printOn: aStream [
 

--- a/src/DataFrame/DataSeries.class.st
+++ b/src/DataFrame/DataSeries.class.st
@@ -664,7 +664,10 @@ DataSeries >> sortedDescending [
 DataSeries >> sum [
 	"Return the sum of the values over the requested axis. Nil values are excluded."
 
-	^ (self reject: #isNil) inject: 0 into: [ :accum :each | accum + each ]
+	| result |
+	result := 0.
+	self do: [ :each | each ifNotNil: [ result := result + each ] ].
+	^ result
 ]
 
 { #category : #statistics }

--- a/src/DataFrame/DataSeries.class.st
+++ b/src/DataFrame/DataSeries.class.st
@@ -660,6 +660,13 @@ DataSeries >> sortedDescending [
 	^ self sorted: [ :a :b | a > b ]
 ]
 
+{ #category : #transformation }
+DataSeries >> sum [
+	"Return the sum of the values over the requested axis. Nil values are excluded."
+
+	^ (self reject: #isNil) inject: 0 into: [ :accum :each | accum + each ]
+]
+
 { #category : #statistics }
 DataSeries >> summary [
 	| summary |

--- a/src/DataFrame/DataSeries.class.st
+++ b/src/DataFrame/DataSeries.class.st
@@ -420,7 +420,8 @@ DataSeries >> isCategorical [
 
 { #category : #'categorical-numerical' }
 DataSeries >> isNumerical [
-	^ forcedIsNumerical ifNil: [self uniqueValues allSatisfy: [:each|each isNumber]]
+
+	^ forcedIsNumerical ifNil: [ (self uniqueValues copyWithout: nil) allSatisfy: [ :each | each isNumber ] ]
 ]
 
 { #category : #testing }

--- a/src/DataFrame/DataSeries.class.st
+++ b/src/DataFrame/DataSeries.class.st
@@ -160,6 +160,13 @@ DataSeries >> atIndex: aNumber transform: aBlock [
 	self at: key transform: aBlock
 ]
 
+{ #category : #information }
+DataSeries >> average [
+	"We do not count the nils"
+
+	^ (self values reject: #isNil) average
+]
+
 { #category : #'data-types' }
 DataSeries >> calculateDataType [
 


### PR DESCRIPTION
This PR fixes various bugs:
- #isNumerical should return true for columns with numbers and nils
- #sum should work on DataSeries with nil values (nils are considered 0)
- #correlationMatrix should be able to compute the correlation for numerical columns with nil values
- Make #average work as #mean in pandas
- Copying a DataFrame pointed to the same internal structure and was not a real copy

All the behavior changes here are matching the behavior of Pandas