### PR TITLE
Improve management of #closeTo:

### DIFF
--- a/src/DataFrame-Tests/DataFrameTest.class.st
+++ b/src/DataFrame-Tests/DataFrameTest.class.st
@@ -462,6 +462,39 @@ DataFrameTest >> testChangeDataTypes [
 ]
 
 { #category : #tests }
+DataFrameTest >> testCloseTo [
+
+	self assert: ((DataFrame withRows: #( #( Barcelona 1.609 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) )) closeTo:
+			 (DataFrame withRows: #( #( Barcelona 1.609 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) ))).
+
+
+	self assert:
+		((DataFrame withRows: #( #( Barcelona 1.609 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) )) closeTo: (DataFrame withRows:
+				  #( #( Barcelona 1.609000000000001 true ) #( Dubai 2.78900000001 true ) #( London 8.788000000001 false ) #( Paris 2.14100000000000005 true ) ))).
+
+	self deny: ((DataFrame withRows: #( #( Barcelona 1.608 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) )) closeTo:
+			 (DataFrame withRows: #( #( Barcelona 1.609 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) )))
+]
+
+{ #category : #tests }
+DataFrameTest >> testCloseToPrecision [
+
+	self assert: ((DataFrame withRows: #( #( Barcelona 1.609 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) ))
+			 closeTo: (DataFrame withRows: #( #( Barcelona 1.609 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) ))
+			 precision: 0.0000001).
+
+
+	self assert: ((DataFrame withRows: #( #( Barcelona 1.609 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) ))
+			 closeTo: (DataFrame withRows:
+					  #( #( Barcelona 1.609000000000001 true ) #( Dubai 2.78900000001 true ) #( London 8.788000000001 false ) #( Paris 2.14100000000000005 true ) ))
+			 precision: 0.0000001).
+
+	self deny: ((DataFrame withRows: #( #( Barcelona 1.608 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) ))
+			 closeTo: (DataFrame withRows: #( #( Barcelona 1.609 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) ))
+			 precision: 0.0000001)
+]
+
+{ #category : #tests }
 DataFrameTest >> testCollect [
 	| expectedDf expectedResult actualResult |
 

--- a/src/DataFrame-Tests/DataFrameTest.class.st
+++ b/src/DataFrame-Tests/DataFrameTest.class.st
@@ -464,33 +464,34 @@ DataFrameTest >> testChangeDataTypes [
 { #category : #tests }
 DataFrameTest >> testCloseTo [
 
-	self assert: ((DataFrame withRows: #( #( Barcelona 1.609 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) )) closeTo:
-			 (DataFrame withRows: #( #( Barcelona 1.609 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) ))).
+	| collection |
+	collection := DataFrame withRows: #( #( Barcelona 1.609 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) ).
+	self assert: (collection closeTo: (DataFrame withRows: #( #( Barcelona 1.609 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) ))).
 
 
-	self assert:
-		((DataFrame withRows: #( #( Barcelona 1.609 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) )) closeTo: (DataFrame withRows:
+	self assert: (collection closeTo: (DataFrame withRows:
 				  #( #( Barcelona 1.609000000000001 true ) #( Dubai 2.78900000001 true ) #( London 8.788000000001 false ) #( Paris 2.14100000000000005 true ) ))).
 
-	self deny: ((DataFrame withRows: #( #( Barcelona 1.608 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) )) closeTo:
-			 (DataFrame withRows: #( #( Barcelona 1.609 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) )))
+	self deny: (collection closeTo: (DataFrame withRows: #( #( Barcelona 1.608 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) )))
 ]
 
 { #category : #tests }
 DataFrameTest >> testCloseToPrecision [
 
-	self assert: ((DataFrame withRows: #( #( Barcelona 1.609 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) ))
+	| collection |
+	collection := DataFrame withRows: #( #( Barcelona 1.609 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) ).
+	self assert: (collection
 			 closeTo: (DataFrame withRows: #( #( Barcelona 1.609 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) ))
 			 precision: 0.0000001).
 
 
-	self assert: ((DataFrame withRows: #( #( Barcelona 1.609 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) ))
+	self assert: (collection
 			 closeTo: (DataFrame withRows:
 					  #( #( Barcelona 1.609000000000001 true ) #( Dubai 2.78900000001 true ) #( London 8.788000000001 false ) #( Paris 2.14100000000000005 true ) ))
 			 precision: 0.0000001).
 
-	self deny: ((DataFrame withRows: #( #( Barcelona 1.608 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) ))
-			 closeTo: (DataFrame withRows: #( #( Barcelona 1.609 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) ))
+	self deny: (collection
+			 closeTo: (DataFrame withRows: #( #( Barcelona 1.608 true ) #( Dubai 2.789 true ) #( London 8.788 false ) #( Paris 2.141 true ) ))
 			 precision: 0.0000001)
 ]
 

--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -559,6 +559,21 @@ DataFrame >> closeTo: aDataFrame [
 	^ true
 ]
 
+{ #category : #comparing }
+DataFrame >> closeTo: aDataFrame precision: epsilon [
+
+	aDataFrame species = self species ifFalse: [ ^ false ].
+
+	aDataFrame dimensions = self dimensions ifFalse: [ ^ false ].
+
+	(aDataFrame rowNames = self rowNames and: [ aDataFrame columnNames = self columnNames ]) ifFalse: [ ^ false ].
+
+	1 to: self numberOfRows do: [ :i |
+	1 to: self numberOfColumns do: [ :j | ((self at: i at: j) closeTo: (aDataFrame at: i at: j) precision: epsilon) ifFalse: [ ^ false ] ] ].
+
+	^ true
+]
+
 { #category : #enumerating }
 DataFrame >> collect: aBlock [
 	"Overrides the Collection>>collect to create DataFrame with the same number of columns as values in the first row"

--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -159,12 +159,6 @@ Class {
 	#category : #'DataFrame-Core'
 }
 
-{ #category : #defaults }
-DataFrame class >> defaultNormalizer [
-
-	^ AIMinMaxNormalizer
-]
-
 { #category : #'instance creation' }
 DataFrame class >> new: aPoint [
 
@@ -541,20 +535,19 @@ DataFrame >> calculateDataTypes [
 { #category : #comparing }
 DataFrame >> closeTo: aDataFrame [
 
-	aDataFrame species = self species
-		ifFalse: [ ^ false ].
+	aDataFrame species = self species ifFalse: [ ^ false ].
 
-	aDataFrame dimensions = self dimensions
-		ifFalse: [ ^ false ].
+	aDataFrame dimensions = self dimensions ifFalse: [ ^ false ].
 
-	(aDataFrame rowNames = self rowNames
-		and: [ aDataFrame columnNames = self columnNames ])
-		ifFalse: [ ^ false ].
+	(aDataFrame rowNames = self rowNames and: [ aDataFrame columnNames = self columnNames ]) ifFalse: [ ^ false ].
 
 	1 to: self numberOfRows do: [ :i |
 		1 to: self numberOfColumns do: [ :j |
-			((self at: i at: j) closeTo: (aDataFrame at: i at: j))
-				ifFalse: [ ^ false ] ] ].
+			| value |
+			value := self at: i at: j.
+			(value isNumber
+				 ifTrue: [ value closeTo: (aDataFrame at: i at: j) ]
+				 ifFalse: [ value = (aDataFrame at: i at: j) ]) ifFalse: [ ^ false ] ] ].
 
 	^ true
 ]
@@ -569,7 +562,12 @@ DataFrame >> closeTo: aDataFrame precision: epsilon [
 	(aDataFrame rowNames = self rowNames and: [ aDataFrame columnNames = self columnNames ]) ifFalse: [ ^ false ].
 
 	1 to: self numberOfRows do: [ :i |
-	1 to: self numberOfColumns do: [ :j | ((self at: i at: j) closeTo: (aDataFrame at: i at: j) precision: epsilon) ifFalse: [ ^ false ] ] ].
+		1 to: self numberOfColumns do: [ :j |
+			| value |
+			value := self at: i at: j.
+			(value isNumber
+				 ifTrue: [ value closeTo: (aDataFrame at: i at: j) precision: epsilon ]
+				 ifFalse: [ value = (aDataFrame at: i at: j) ]) ifFalse: [ ^ false ] ] ].
 
 	^ true
 ]
@@ -1381,11 +1379,11 @@ DataFrame >> normalized [
 	"This methods returns a new DataFrame, without altering this one, that has all the columns normalized."
 
 	| normalizers normalizedColumns |
-	normalizers := (1 to: self anyOne size) collect: [ :e |  self class defaultNormalizer new ].
+	self deprecated:
+		'DataFrame will remove the dependency over normalization in the next version. You can use pharo-ai/data-preprocessing project to normalize your DataFrame and even more!'.
+	normalizers := (1 to: self anyOne size) collect: [ :e | self class defaultNormalizerClass new ].
 
-	normalizedColumns := self columns
-		with: normalizers
-		collect: [ :col :normalizer | col normalizedUsing: normalizer ].
+	normalizedColumns := self columns with: normalizers collect: [ :col :normalizer | col normalizedUsing: normalizer ].
 
 	^ self class withColumns: normalizedColumns columnNames: self columnNames
 ]


### PR DESCRIPTION
* #closeTo: now only use #closeTo: on numbers and not on all objects because Object>>#closeTo: is a hack from the Finder
* Add #closeTo:precision: to make DataFrame be able to be a parameter of #assert:closeTo: that relies on it
* Add tests