### PR TITLE
Statistical methods such as stdev, max and min can now handle nils.

### DIFF
--- a/src/DataFrame-Tests/DataSeriesTest.class.st
+++ b/src/DataFrame-Tests/DataSeriesTest.class.st
@@ -1600,6 +1600,18 @@ DataSeriesTest >> testMaxWithNils [
 	self assert: #( 1 nil 3 nil ) asDataSeries max equals: 3
 ]
 
+{ #category : #tests }
+DataSeriesTest >> testMedian [
+
+	self assert: #( 1 2 3 4 5 ) asDataSeries median equals: 3
+]
+
+{ #category : #tests }
+DataSeriesTest >> testMedianWithNils [
+
+	self assert: #( 1 2 nil 3 4 nil 5 ) asDataSeries median equals: 3
+]
+
 { #category : #'tests - statistics' }
 DataSeriesTest >> testMin [
 

--- a/src/DataFrame-Tests/DataSeriesTest.class.st
+++ b/src/DataFrame-Tests/DataSeriesTest.class.st
@@ -1588,6 +1588,30 @@ DataSeriesTest >> testMathTan [
 	self assert: a tan closeTo: b
 ]
 
+{ #category : #'tests - statistics' }
+DataSeriesTest >> testMax [
+
+	self assert: #( 1 2 3 4 ) asDataSeries max equals: 4
+]
+
+{ #category : #'tests - statistics' }
+DataSeriesTest >> testMaxWithNils [
+
+	self assert: #( 1 nil 3 nil ) asDataSeries max equals: 3
+]
+
+{ #category : #'tests - statistics' }
+DataSeriesTest >> testMin [
+
+	self assert: #( 1 2 3 4 ) asDataSeries min equals: 1
+]
+
+{ #category : #'tests - statistics' }
+DataSeriesTest >> testMinWithNils [
+
+	self assert: #( nil 2 nil 4 ) asDataSeries min equals: 2
+]
+
 { #category : #'tests - creation' }
 DataSeriesTest >> testNewFrom [
 
@@ -2174,6 +2198,18 @@ DataSeriesTest >> testStatsZerothQuartile [
 DataSeriesTest >> testStatsZerothQuartileEqualsMin [
 
 	self assert: series zerothQuartile equals: series min
+]
+
+{ #category : #'tests - statistics' }
+DataSeriesTest >> testStdev [
+
+	self assert: #( 1 2 3 ) asDataSeries stdev equals: 1
+]
+
+{ #category : #tests }
+DataSeriesTest >> testStdevWithNils [
+
+	self assert: #( 1 nil 2 nil 3 ) asDataSeries stdev equals: 1
 ]
 
 { #category : #'tests - arithmetic' }

--- a/src/DataFrame/DataSeries.class.st
+++ b/src/DataFrame/DataSeries.class.st
@@ -520,6 +520,20 @@ DataSeries >> makeNumerical [
 	forcedIsNumerical := true
 ]
 
+{ #category : #statistics }
+DataSeries >> max [
+	"Returns the maximum value of the dataseries without including nils"
+
+	^ (self values reject: #isNil) max
+]
+
+{ #category : #statistics }
+DataSeries >> min [
+	"Returns the minimum value of the dataseries without including nils"
+
+	^ (self values reject: #isNil) min
+]
+
 { #category : #accessing }
 DataSeries >> mode [
 	"The mode of a set of values is the value that appears most often. "
@@ -755,6 +769,13 @@ DataSeries >> sortedDescending [
 	"Returns a sorted copy of the data series in descending order without rearranging the original data series"
 
 	^ self sorted: [ :a :b | a > b ]
+]
+
+{ #category : #statistics }
+DataSeries >> stdev [
+	"Returns the standard deviation of the dataseries without including nils"
+
+	^ (self values reject: #isNil) stdev
 ]
 
 { #category : #transformation }

--- a/src/DataFrame/DataSeries.class.st
+++ b/src/DataFrame/DataSeries.class.st
@@ -167,11 +167,11 @@ DataSeries >> atIndex: aNumber transform: aBlock [
 	self at: key transform: aBlock
 ]
 
-{ #category : #information }
+{ #category : #statistics }
 DataSeries >> average [
-	"We do not count the nils"
+	"Returns the average without including nils"
 
-	^ (self values reject: #isNil) average
+	^ self removeNils values average
 ]
 
 { #category : #'data-types' }
@@ -524,14 +524,21 @@ DataSeries >> makeNumerical [
 DataSeries >> max [
 	"Returns the maximum value of the dataseries without including nils"
 
-	^ (self values reject: #isNil) max
+	^ self removeNils values max
+]
+
+{ #category : #statistics }
+DataSeries >> median [
+	"Returns the median without including nils"
+
+	^ self removeNils values median
 ]
 
 { #category : #statistics }
 DataSeries >> min [
 	"Returns the minimum value of the dataseries without including nils"
 
-	^ (self values reject: #isNil) min
+	^ self removeNils values min
 ]
 
 { #category : #accessing }
@@ -775,7 +782,7 @@ DataSeries >> sortedDescending [
 DataSeries >> stdev [
 	"Returns the standard deviation of the dataseries without including nils"
 
-	^ (self values reject: #isNil) stdev
+	^ self removeNils values stdev
 ]
 
 { #category : #transformation }


### PR DESCRIPTION
Tests have been written to check if these methods work properly if a dataseries has nil values and if it doesn't have nil values.

This fixes issue #227.