### PR TITLE
#numericalColumns now returns an array of all numerical columns

### DIFF
--- a/src/DataFrame-Tests/DataFrameTest.class.st
+++ b/src/DataFrame-Tests/DataFrameTest.class.st
@@ -2833,7 +2833,7 @@ DataFrameTest >> testNumericalColumnNames [
 		                #( Female 22 Spain 95 ) #( Male 24 Portugal 99 ) ).
 	dataFrame columnNames: #( Gender Age Country Score ).
 
-	expected := #( Age Score ).
+	expected := #( Age Score ) asOrderedCollection.
 
 	self assert: dataFrame numericalColumnNames equals: expected
 ]

--- a/src/DataFrame-Tests/DataFrameTest.class.st
+++ b/src/DataFrame-Tests/DataFrameTest.class.st
@@ -2833,7 +2833,7 @@ DataFrameTest >> testNumericalColumnNames [
 		                #( Female 22 Spain 95 ) #( Male 24 Portugal 99 ) ).
 	dataFrame columnNames: #( Gender Age Country Score ).
 
-	expected := #( Age Score ) asOrderedCollection.
+	expected := #( Age Score ).
 
 	self assert: dataFrame numericalColumnNames equals: expected
 ]
@@ -2841,18 +2841,17 @@ DataFrameTest >> testNumericalColumnNames [
 { #category : #tests }
 DataFrameTest >> testNumericalColumns [
 
-	| dataFrame expected |
+	| dataFrame expectedCollection |
 	dataFrame := DataFrame withRows:
 		             #( #( Male 21 Argentina 94 ) #( Female 20 France 97 )
 		                #( Female 22 Spain 95 ) #( Male 24 Portugal 99 ) ).
 	dataFrame columnNames: #( Gender Age Country Score ).
 
-	expected := DataFrame withRows:
-		            #( #( 21 94 ) #( 20 97 ) #( 22 95 ) #( 24 99 ) ).
+	expectedCollection := {
+		                      (dataFrame columnAt: 2).
+		                      (dataFrame columnAt: 4) } asArray.
 
-	expected columnNames: #( Age Score ).
-
-	self assert: dataFrame numericalColumns equals: expected
+	self assert: dataFrame numericalColumns equals: expectedCollection
 ]
 
 { #category : #splitjoin }

--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -1431,7 +1431,8 @@ DataFrame >> numberOfRows [
 DataFrame >> numericalColumnNames [
 	"Returns the names of all numerical columns of the dataframe"
 
-	^ self numericalColumns collect: [ :column | column name ]
+	^ self columnNames select: [ :columnName |
+		  (self dataTypes at: columnName) includesBehavior: Number ]
 ]
 
 { #category : #accessing }

--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -1431,15 +1431,15 @@ DataFrame >> numberOfRows [
 DataFrame >> numericalColumnNames [
 	"Returns the names of all numerical columns of the dataframe"
 
-	^ self columnNames select: [ :columnName |
-		  (self dataTypes at: columnName) includesBehavior: Number ]
+	^ self numericalColumns collect: [ :column | column name ]
 ]
 
 { #category : #accessing }
 DataFrame >> numericalColumns [
 	"Returns all numerical columns of the dataframe"
 
-	^ self columns: self numericalColumnNames
+	^ self columns select: [ :column |
+		  (self dataTypes at: column name) includesBehavior: Number ]
 ]
 
 { #category : #splitjoin }


### PR DESCRIPTION
#numericalColumns currently returns a DataFrame of only the numerical columns in the original DataFrame, it should return an array of numerical columns.