### PR TITLE
Add methods to draw a scatter plot matrix of a DataFrame

### DIFF
--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -408,6 +408,21 @@ DataFrame >> addRow: anArray named: aString atPosition: aNumber [
 	rowNames add: aString afterIndex: aNumber - 1
 ]
 
+{ #category : #plot }
+DataFrame >> addScatterPlotShapeToChart: aRSChart [
+	" Assume a receiver with two first columns as x and y coordinates. 
+	Requires Roassal 3. Answer a Roassal scatter plot shape with points color configured to aColor "
+	
+	| scatterPlot x y |
+	
+	x := (self columnAt: 1) asOrderedCollection.
+	y := (self columnAt: 2) asOrderedCollection.
+	scatterPlot := RSScatterPlot new x: x y: y.
+	aRSChart addPlot: scatterPlot.
+	^ scatterPlot
+
+]
+
 { #category : #applying }
 DataFrame >> applyElementwise: aBlock [
 	"Applies a given block to all columns of a data frame"
@@ -1393,6 +1408,31 @@ DataFrame >> numberOfRows [
 	"Returns the number of rows of a DataFrame"
 
 	^ contents numberOfRows
+]
+
+{ #category : #plot }
+DataFrame >> openScatterPlotWithTitle: aString forColumn: columnName [
+	" Assume a receiver with two first columns as x and y coordinates. 
+	Requires Roassal 3. Plot and open a new window"
+	
+	| roassalChart scatterPlotShapes uniqueColumns |
+	roassalChart := RSChart new
+		title: aString;
+		addDecoration: (RSHorizontalTick new doNotUseNiceLabel asFloat: 3);
+		addDecoration: RSVerticalTick new;
+		yourself.
+	uniqueColumns := (self column: columnName) asSet.
+	scatterPlotShapes := uniqueColumns collect: [ : type | 
+		(self select: [ : e | e values includes: type ]) 
+			addScatterPlotShapeToChart: roassalChart ].
+
+	scatterPlotShapes asOrderedCollection
+		with: ((1 to: uniqueColumns size) collect: [ : c | Color random ])
+		do: [ : scatterPlotShape  : scatterPlotDotColor |
+			scatterPlotShape color: scatterPlotDotColor ].
+	roassalChart padding: 10.
+
+	roassalChart open.
 ]
 
 { #category : #splitjoin }


### PR DESCRIPTION
Usage example using PCA:

```smalltalk
	| d m pca m1 d1 irisDataFrame |
	
	irisDataFrame := AIDatasets loadIris.
	d := irisDataFrame columnsFrom: 1 to: 4.

	"Transform DF  as matrix"
	m := PMMatrix rows: d asArrayOfRows.

	"Data standardization (mean = 0 and variance = 1)"
	m := PMStandardizationScaler new fitAndTransform: m.

	"Compute PCA components"
	pca := PMPrincipalComponentAnalyserSVD new.
	pca componentsNumber: 2.
	pca fit: m.
	pca transformMatrix.

	m1 := pca transform: m.

	d1 := DataFrame withRows: m1 rows.
	d1
		addColumn: (irisDataFrame columnsFrom: 5 to: 5) asArrayOfColumns first
		named: 'type'.
		
	d1 	
		openScatterPlotWithTitle: 'PCA of Iris data set' 
		forColumn: 'type'.
```
