### PR TITLE
Added DataFrame>> #toMarkdown along with tests

### DIFF
--- a/src/DataFrame-Tests/DataFrameTest.class.st
+++ b/src/DataFrame-Tests/DataFrameTest.class.st
@@ -5134,6 +5134,19 @@ DataFrameTest >> testToColumnsAtApplyElementwise [
 ]
 
 { #category : #tests }
+DataFrameTest >> testToMarkdown [
+
+	| expectedString |
+	expectedString := '| #   | City        | Population | BeenThere | 
+| --- | ----------- | ---------- | --------- | 
+| ''A'' | ''Barcelona'' | 1.609      | true      | 
+| ''B'' | ''Dubai''     | 2.789      | true      | 
+| ''C'' | ''London''    | 8.788      | false     | 
+'.
+	self assert: df toMarkdown equals: expectedString
+]
+
+{ #category : #tests }
 DataFrameTest >> testTransposed [
 
 	| expected |

--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -2259,6 +2259,51 @@ DataFrame >> toColumnsAt: arrayOfColumnNumbers applyElementwise: aBlock [
 		self toColumnAt: each applyElementwise: aBlock ]
 ]
 
+{ #category : #converting }
+DataFrame >> toMarkdown [
+	" Prints the DataFrame as a Markdown formatted table"
+
+	| markdown columnWidths |
+	self addColumn: self rowNames named: '#' atPosition: 1.
+	markdown := WriteStream on: String new.
+	markdown nextPutAll: '| '.
+
+	columnWidths := self columnNames collect: [ :columnName |
+		                | maxWidth |
+		                maxWidth := columnName size.
+		                self rows do: [ :row |
+			                | value |
+			                value := row at: columnName.
+			                maxWidth := maxWidth max: value printString size ].
+		                maxWidth ].
+
+	self columnNames withIndexDo: [ :columnName :index |
+		| paddedColumnName |
+		paddedColumnName := columnName padRightTo: (columnWidths at: index).
+		markdown nextPutAll: paddedColumnName , ' | ' ].
+	markdown cr.
+	markdown nextPutAll: '| '.
+
+	columnWidths do: [ :width |
+		| secondRow |
+		secondRow := '-'.
+		width - 1 timesRepeat: [ secondRow := secondRow , '-' ].
+		markdown nextPutAll: secondRow , ' | ' ].
+
+	markdown cr.
+
+	self asArrayOfRows do: [ :row |
+		markdown nextPutAll: '| '.
+		row withIndexDo: [ :value :index |
+			| paddedValue |
+			paddedValue := value printString padRightTo:
+				               (columnWidths at: index).
+			markdown nextPutAll: paddedValue , ' | ' ].
+		markdown cr ].
+
+	^ markdown contents
+]
+
 { #category : #geometry }
 DataFrame >> transposed [
 	"Returns a transposed DataFrame. Columns become rows and rows become columns."

--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -2263,21 +2263,22 @@ DataFrame >> toColumnsAt: arrayOfColumnNumbers applyElementwise: aBlock [
 DataFrame >> toMarkdown [
 	" Prints the DataFrame as a Markdown formatted table"
 
-	| markdown columnWidths |
-	self addColumn: self rowNames named: '#' atPosition: 1.
+	| markdown columnWidths dataFrame |
+	dataFrame := self copy.
+	dataFrame addColumn: dataFrame rowNames named: '#' atPosition: 1.
 	markdown := WriteStream on: String new.
 	markdown nextPutAll: '| '.
 
-	columnWidths := self columnNames collect: [ :columnName |
+	columnWidths := dataFrame columnNames collect: [ :columnName |
 		                | maxWidth |
 		                maxWidth := columnName size.
-		                self rows do: [ :row |
+		                dataFrame rows do: [ :row |
 			                | value |
 			                value := row at: columnName.
 			                maxWidth := maxWidth max: value printString size ].
 		                maxWidth ].
 
-	self columnNames withIndexDo: [ :columnName :index |
+	dataFrame columnNames withIndexDo: [ :columnName :index |
 		| paddedColumnName |
 		paddedColumnName := columnName padRightTo: (columnWidths at: index).
 		markdown nextPutAll: paddedColumnName , ' | ' ].
@@ -2292,7 +2293,7 @@ DataFrame >> toMarkdown [
 
 	markdown cr.
 
-	self asArrayOfRows do: [ :row |
+	dataFrame asArrayOfRows do: [ :row |
 		markdown nextPutAll: '| '.
 		row withIndexDo: [ :value :index |
 			| paddedValue |


### PR DESCRIPTION
I've implemented a method `toMarkdown` so that DataFrames can be converted to a Markdown formatted table.

```smallTalk
	df := DataFrame withRows:
		      #( #( 'Barcelona' 1.609 true ) 
                         #( 'Dubai' 2.789 true )
		         #( 'London' 8.788 false ) ).

	df rowNames: #( 'A' 'B' 'C' ).
	df columnNames: #( 'City' 'Population' 'BeenThere' ).

df toMarkdown.
```
This should return a string which can be copy-pasted in an editor which supports Markdown.

```
| #   | City        | Population | BeenThere | 
| --- | ----------- | ---------- | --------- | 
| 'A' | 'Barcelona' | 1.609      | true      | 
| 'B' | 'Dubai'     | 2.789      | true      | 
| 'C' | 'London'    | 8.788      | false     | 
```
It would look like this once this text is pasted in a Markdown supported editor : 
| #   | City        | Population | BeenThere | 
| --- | ----------- | ---------- | --------- | 
| 'A' | 'Barcelona' | 1.609      | true      | 
| 'B' | 'Dubai'     | 2.789      | true      | 
| 'C' | 'London'    | 8.788      | false     | 