### PR TITLE
Added DataFrame>> #toLatex with tests

### DIFF
--- a/src/DataFrame-Tests/DataFrameTest.class.st
+++ b/src/DataFrame-Tests/DataFrameTest.class.st
@@ -5134,6 +5134,25 @@ DataFrameTest >> testToColumnsAtApplyElementwise [
 ]
 
 { #category : #tests }
+DataFrameTest >> testToLatex [
+
+	| expectedString |
+	expectedString := '\begin{tabular}{|l|l|l|l|}
+\hline
+\#  & City        & Population & BeenThere\\
+\hline
+''A'' & ''Barcelona'' & 1.609      & true     \\
+\hline
+''B'' & ''Dubai''     & 2.789      & true     \\
+\hline
+''C'' & ''London''    & 8.788      & false    \\
+\hline
+\end{tabular}'.
+
+	self assert: df toLatex equals: expectedString
+]
+
+{ #category : #tests }
 DataFrameTest >> testToMarkdown [
 
 	| expectedString |

--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -2260,6 +2260,59 @@ DataFrame >> toColumnsAt: arrayOfColumnNumbers applyElementwise: aBlock [
 ]
 
 { #category : #converting }
+DataFrame >> toLatex [
+	" Prints the DataFrame as a Latex formatted table"
+
+	| markdown columnWidths dataFrame |
+	dataFrame := self copy.
+	dataFrame addColumn: dataFrame rowNames named: '\#' atPosition: 1.
+	markdown := WriteStream on: String new.
+	markdown nextPutAll: '\begin{tabular}{|'.
+	dataFrame numberOfColumns timesRepeat: [ markdown nextPutAll: 'l|' ].
+	markdown nextPutAll: '}'.
+	markdown cr.
+	markdown nextPutAll: '\hline'.
+	markdown cr.
+
+	columnWidths := dataFrame columnNames collect: [ :columnName |
+		                | maxWidth |
+		                maxWidth := columnName size.
+		                dataFrame rows do: [ :row |
+			                | value |
+			                value := row at: columnName.
+			                maxWidth := maxWidth max: value printString size ].
+		                maxWidth ].
+
+	dataFrame columnNames withIndexDo: [ :columnName :index |
+		| paddedColumnName |
+		paddedColumnName := columnName padRightTo: (columnWidths at: index).
+		index = dataFrame numberOfColumns
+			ifFalse: [ markdown nextPutAll: paddedColumnName , ' & ' ]
+			ifTrue: [ markdown nextPutAll: paddedColumnName ] ].
+	markdown nextPutAll: '\\'.
+	markdown cr.
+	markdown nextPutAll: '\hline'.
+	markdown cr.
+
+
+
+	dataFrame asArrayOfRows do: [ :row |
+		row withIndexDo: [ :value :index |
+			| paddedValue |
+			paddedValue := value printString padRightTo:
+				               (columnWidths at: index).
+			index = dataFrame numberOfColumns
+				ifFalse: [ markdown nextPutAll: paddedValue , ' & ' ]
+				ifTrue: [ markdown nextPutAll: paddedValue ] ].
+		markdown nextPutAll: '\\'.
+		markdown cr.
+		markdown nextPutAll: '\hline'.
+		markdown cr ].
+	markdown nextPutAll: '\end{tabular}'.
+	^ markdown contents
+]
+
+{ #category : #converting }
 DataFrame >> toMarkdown [
 	" Prints the DataFrame as a Markdown formatted table"
 


### PR DESCRIPTION
I've implemented a method `toLatex` so that DataFrames can be converted to a Latex formatted table.
```
	df := DataFrame withRows:
		      #( #( 'Barcelona' 1.609 true ) 
                         #( 'Dubai' 2.789 true )
		         #( 'London' 8.788 false ) ).

	df rowNames: #( 'A' 'B' 'C' ).
	df columnNames: #( 'City' 'Population' 'BeenThere' ).

df toLatex.
```
This should return a string which can be copy-pasted in a latex-text editor.
```
\begin{tabular}{|l|l|l|l|}
\hline
\#  & City        & Population & BeenThere\\
\hline
'A' & 'Barcelona' & 1.609      & true     \\
\hline
'B' & 'Dubai'     & 2.789      & true     \\
\hline
'C' & 'London'    & 8.788      & false    \\
\hline
\end{tabular}
```
It would look like this once this text is compiled in a Latex supported editor :
![image](https://github.com/PolyMathOrg/DataFrame/assets/99500414/31bc1640-d748-46e7-b44e-d317f8f0a106)
