### PR TITLE
Added DataFrame>> #toHtml

### DIFF
--- a/src/DataFrame-Tests/DataFrameTest.class.st
+++ b/src/DataFrame-Tests/DataFrameTest.class.st
@@ -5134,6 +5134,40 @@ DataFrameTest >> testToColumnsAtApplyElementwise [
 ]
 
 { #category : #tests }
+DataFrameTest >> testToHtml [
+
+	| expectedString |
+	expectedString := '<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: left;">      <th>#  </th>
+      <th>City       </th>
+      <th>Population</th>
+      <th>BeenThere</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>      <th>''A''</th>
+      <td>''Barcelona''</td>
+      <td>1.609     </td>
+      <td>true     </td>
+    </tr>
+    <tr>      <th>''B''</th>
+      <td>''Dubai''    </td>
+      <td>2.789     </td>
+      <td>true     </td>
+    </tr>
+    <tr>      <th>''C''</th>
+      <td>''London''   </td>
+      <td>8.788     </td>
+      <td>false    </td>
+    </tr>
+  </tbody>
+</table>'.
+
+	self assert: df toHtml equals: expectedString
+]
+
+{ #category : #tests }
 DataFrameTest >> testToLatex [
 
 	| expectedString |

--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -2260,6 +2260,80 @@ DataFrame >> toColumnsAt: arrayOfColumnNumbers applyElementwise: aBlock [
 ]
 
 { #category : #converting }
+DataFrame >> toHtml [
+	"Prints the DataFrame as an HTML formatted table"
+
+	| html columnWidths dataFrame |
+	dataFrame := self copy.
+	dataFrame addColumn: dataFrame rowNames named: '#' atPosition: 1.
+	html := WriteStream on: String new.
+	html
+		nextPutAll: '<table border="1" class="dataframe">';
+		cr;
+		nextPutAll: '  <thead>';
+		cr;
+		nextPutAll: '    <tr style="text-align: left;">'.
+
+	columnWidths := dataFrame columnNames collect: [ :columnName |
+		                | maxWidth |
+		                maxWidth := columnName size.
+		                dataFrame rows do: [ :row |
+			                | value |
+			                value := row at: columnName.
+			                maxWidth := maxWidth max: value printString size ].
+		                maxWidth ].
+
+	dataFrame columnNames withIndexDo: [ :columnName :index |
+		| paddedColumnName |
+		paddedColumnName := columnName padRightTo: (columnWidths at: index).
+		html
+			nextPutAll: '      <th>';
+			nextPutAll: paddedColumnName;
+			nextPutAll: '</th>';
+			cr ].
+
+	html
+		nextPutAll: '    </tr>';
+		cr;
+		nextPutAll: '  </thead>';
+		cr;
+		nextPutAll: '  <tbody>';
+		cr.
+
+	dataFrame asArrayOfRows do: [ :row |
+		html nextPutAll: '    <tr>'.
+
+		row withIndexDo: [ :value :index |
+			| paddedValue |
+			paddedValue := value printString padRightTo:
+				               (columnWidths at: index).
+			index = 1
+				ifFalse: [
+					html
+						nextPutAll: '      <td>';
+						nextPutAll: paddedValue;
+						nextPutAll: '</td>';
+						cr ]
+				ifTrue: [
+					html
+						nextPutAll: '      <th>';
+						nextPutAll: paddedValue;
+						nextPutAll: '</th>';
+						cr ] ].
+
+		html
+			nextPutAll: '    </tr>';
+			cr ].
+
+	html
+		nextPutAll: '  </tbody>';
+		cr;
+		nextPutAll: '</table>'.
+
+	^ html contents
+]
+
+{ #category : #converting }
 DataFrame >> toLatex [
 	" Prints the DataFrame as a Latex formatted table"
 


### PR DESCRIPTION
I've implemented a method `toHtml` so that DataFrames can be converted to an html table.
```
	df := DataFrame withRows:
		      #( #( 'Barcelona' 1.609 true ) 
                         #( 'Dubai' 2.789 true )
		         #( 'London' 8.788 false ) ).

	df rowNames: #( 'A' 'B' 'C' ).
	df columnNames: #( 'City' 'Population' 'BeenThere' ).

df toHtml.
```
This should return a string which can be copy-pasted in an html editor.
```
<table border="1" class="dataframe">
  <thead>
    <tr style="text-align: left;">      <th>#  </th>
      <th>City       </th>
      <th>Population</th>
      <th>BeenThere</th>
    </tr>
  </thead>
  <tbody>
    <tr>      <th>'A'</th>
      <td>'Barcelona'</td>
      <td>1.609     </td>
      <td>true     </td>
    </tr>
    <tr>      <th>'B'</th>
      <td>'Dubai'    </td>
      <td>2.789     </td>
      <td>true     </td>
    </tr>
    <tr>      <th>'C'</th>
      <td>'London'   </td>
      <td>8.788     </td>
      <td>false    </td>
    </tr>
  </tbody>
</table>
```
It would look like this once this text is compiled in an html editor :
![image](https://github.com/PolyMathOrg/DataFrame/assets/99500414/38844936-5758-4761-ab68-f8274aded022)
