### PR TITLE
Added DataFrame>> #toString. Fixed #126.

### DIFF
--- a/src/DataFrame-Tests/DataFrameTest.class.st
+++ b/src/DataFrame-Tests/DataFrameTest.class.st
@@ -5200,6 +5200,19 @@ DataFrameTest >> testToMarkdown [
 ]
 
 { #category : #tests }
+DataFrameTest >> testToString [
+
+	| expectedString |
+	expectedString := '#    City         Population  BeenThere  
+''A''  ''Barcelona''  1.609       true       
+''B''  ''Dubai''      2.789       true       
+''C''  ''London''     8.788       false      
+'.
+
+	self assert: df toString equals: expectedString
+]
+
+{ #category : #tests }
 DataFrameTest >> testTransposed [
 
 	| expected |

--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -2432,6 +2432,43 @@ DataFrame >> toMarkdown [
 	^ markdown contents
 ]
 
+{ #category : #converting }
+DataFrame >> toString [
+	" Prints the DataFrame as a String formatted table"
+
+	| stringTable columnWidths dataFrame |
+	dataFrame := self copy.
+	dataFrame addColumn: dataFrame rowNames named: '#' atPosition: 1.
+	stringTable := WriteStream on: String new.
+
+	columnWidths := dataFrame columnNames collect: [ :columnName |
+		                | maxWidth |
+		                maxWidth := columnName size.
+		                dataFrame rows do: [ :row |
+			                | value |
+			                value := row at: columnName.
+			                maxWidth := maxWidth max: value printString size ].
+		                maxWidth ].
+
+	dataFrame columnNames withIndexDo: [ :columnName :index |
+		| paddedColumnName |
+		paddedColumnName := columnName padRightTo: (columnWidths at: index).
+		stringTable nextPutAll: paddedColumnName, '  ' ].
+	stringTable cr.
+
+
+
+	dataFrame asArrayOfRows do: [ :row |
+		row withIndexDo: [ :value :index |
+			| paddedValue |
+			paddedValue := value printString padRightTo:
+				               (columnWidths at: index).
+			stringTable nextPutAll: paddedValue , '  ' ].
+		stringTable cr ].
+
+	^ stringTable contents
+]
+
 { #category : #geometry }
 DataFrame >> transposed [
 	"Returns a transposed DataFrame. Columns become rows and rows become columns."


### PR DESCRIPTION
I've implemented a method `toString` so that DataFrames can be converted to a string table.
```
	df := DataFrame withRows:
		      #( #( 'Barcelona' 1.609 true ) 
                         #( 'Dubai' 2.789 true )
		         #( 'London' 8.788 false ) ).

	df rowNames: #( 'A' 'B' 'C' ).
	df columnNames: #( 'City' 'Population' 'BeenThere' ).

df toString.
```
This should return a string which looks like a DataFrame
```
#    City         Population  BeenThere  
'A'  'Barcelona'  1.609       true       
'B'  'Dubai'      2.789       true       
'C'  'London'     8.788       false      
```