### PR TITLE
Fixed #106. DataFrame>> #addRow: now considers key ordering

### DIFF
--- a/src/DataFrame-Tests/DataFrameTest.class.st
+++ b/src/DataFrame-Tests/DataFrameTest.class.st
@@ -237,6 +237,28 @@ DataFrameTest >> testAddRowAtPosition [
 ]
 
 { #category : #tests }
+DataFrameTest >> testAddRowAtPositionWithKeysAsColumnNames [
+	| row expected |
+
+	row := DataSeries
+		       withKeys: #( 'Population' 'BeenThere' 'City' )
+		       values: #( 2.141 true Paris )
+		       name: 'X'.
+	df addRow: row atPosition: 2.
+
+	expected := DataFrame withRows: #(
+		(Barcelona 1.609 true)
+		(Paris 2.141 true)
+   		(Dubai 2.789 true)
+   		(London 8.788 false)).
+
+	expected rowNames: #(A X B C).
+	expected columnNames: #(City Population BeenThere).
+
+	self assert: df equals: expected
+]
+
+{ #category : #tests }
 DataFrameTest >> testAddRowNameMustBeDistinct [
 
 	| series |
@@ -293,6 +315,28 @@ DataFrameTest >> testAddRowSizeMismatch [
 	aBlock := [ df addRow: #(1 2) named: 'TooSmall' ].
 
 	self should: aBlock raise: SizeMismatch
+]
+
+{ #category : #tests }
+DataFrameTest >> testAddRowWithKeysAsColumnNames [
+
+	| row expected |
+	row := DataSeries
+		       withKeys: #( 'Population' 'BeenThere' 'City' )
+		       values: #( 2.141 true Paris )
+		       name: 'X'.
+	df addRow: row.
+
+	expected := DataFrame withRows:
+		            #( #( Barcelona 1.609 true ) 
+							#( Dubai 2.789 true )
+		               #( London 8.788 false ) 
+							#( Paris 2.141 true ) ).
+
+	expected rowNames: #( A B C X ).
+	expected columnNames: #( City Population BeenThere ).
+
+	self assert: df equals: expected
 ]
 
 { #category : #tests }

--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -2180,6 +2180,13 @@ DataFrame >> size [
 ]
 
 { #category : #sorting }
+DataFrame >> sortBy: columnName [
+	"Rearranges the rows of the data frame in ascending order of the values in the column named columnName"
+
+	self sortBy: columnName using: [ :a :b | a <= b ]
+]
+
+{ #category : #sorting }
 DataFrame >> sortBy: columnName using: aBlock [
 	"Rearranges the rows of the data frame by applying the given block on the column named columnName"
 

--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -398,15 +398,7 @@ DataFrame >> addEmptyRowNamed: aString atPosition: aNumber [
 DataFrame >> addRow: aDataSeries [
 	"Add DataSeries as a new row at the end"
 
-	| row |
-	row := Array new: self columnNames size.
-	self columnNames withIndexDo: [ :columnName :index |
-		| value |
-		value := aDataSeries
-			         at: columnName
-			         ifAbsent: [ aDataSeries atIndex: index ].
-		row at: index put: value ].
-	self addRow: row named: aDataSeries name
+	self addRow: aDataSeries atPosition: self numberOfRows + 1
 ]
 
 { #category : #adding }

--- a/src/DataFrame/DataFrame.class.st
+++ b/src/DataFrame/DataFrame.class.st
@@ -397,13 +397,31 @@ DataFrame >> addEmptyRowNamed: aString atPosition: aNumber [
 { #category : #adding }
 DataFrame >> addRow: aDataSeries [
 	"Add DataSeries as a new row at the end"
-	self addRow: aDataSeries asArray named: aDataSeries name
+
+	| row |
+	row := Array new: self columnNames size.
+	self columnNames withIndexDo: [ :columnName :index |
+		| value |
+		value := aDataSeries
+			         at: columnName
+			         ifAbsent: [ aDataSeries atIndex: index ].
+		row at: index put: value ].
+	self addRow: row named: aDataSeries name
 ]
 
 { #category : #adding }
 DataFrame >> addRow: aDataSeries atPosition: aNumber [
 	"Add DataSeries as a new row at the given position"
-	self addRow: aDataSeries named: aDataSeries name atPosition: aNumber
+
+	| row |
+	row := Array new: self columnNames size.
+	self columnNames withIndexDo: [ :columnName :index |
+		| value |
+		value := aDataSeries
+			         at: columnName
+			         ifAbsent: [ aDataSeries atIndex: index ].
+		row at: index put: value ].
+	self addRow: row named: aDataSeries name atPosition: aNumber
 ]
 
 { #category : #adding }
@@ -2159,13 +2177,6 @@ DataFrame >> size [
 	"Returns the number of rows of a DataFrame"
 	
 	^ self numberOfRows
-]
-
-{ #category : #sorting }
-DataFrame >> sortBy: columnName [
-	"Rearranges the rows of the data frame in ascending order of the values in the column named columnName"
-	
-	self sortBy: columnName using: [ :a :b | a <= b ]
 ]
 
 { #category : #sorting }


### PR DESCRIPTION
DataFrame>> #addRow: and #addRowAtPosition:  now considers key ordering. 