### PR TITLE
Fixed #257. DataSeries>> #removeNils and #withoutNils work differently

### DIFF
--- a/src/DataFrame-Tests/DataSeriesTest.class.st
+++ b/src/DataFrame-Tests/DataSeriesTest.class.st
@@ -1783,22 +1783,28 @@ DataSeriesTest >> testRemoveDuplicates [
 DataSeriesTest >> testRemoveNils [
 
 	| expected |
-
-	series := DataSeries withKeys: #(1 2 'a' 3) values: #(nil 4.2 'b' nil).
-	expected := DataSeries withKeys: #(2 'a') values: #(4.2 'b').
-
-	self assert: series removeNils equals: expected
+	series := DataSeries
+		          withKeys: #( 1 2 'a' 3 )
+		          values: #( nil 4.2 'b' nil ).
+	expected := DataSeries withKeys: #( 2 'a' ) values: #( 4.2 'b' ).
+	self assert: series removeNils equals: expected.
+	self assert: series equals: expected
 ]
 
 { #category : #'tests - removing' }
 DataSeriesTest >> testRemoveNilsOnNamedSeries [
 
 	| expected |
-
-	series := DataSeries withKeys: #(1 2 'a' 3) values: #(nil 4.2 'b' nil) name: 'A'.
-	expected := DataSeries withKeys: #(2 'a') values: #(4.2 'b') name: 'A'.
-
-	self assert: series removeNils equals: expected
+	series := DataSeries
+		          withKeys: #( 1 2 'a' 3 )
+		          values: #( nil 4.2 'b' nil )
+		          name: 'A'.
+	expected := DataSeries
+		            withKeys: #( 2 'a' )
+		            values: #( 4.2 'b' )
+		            name: 'A'.
+	self assert: series removeNils equals: expected.
+	self assert: series equals: expected
 ]
 
 { #category : #'tests - missing values' }
@@ -2483,4 +2489,34 @@ DataSeriesTest >> testWithKeySelect [
 
 	actual := series withKeySelect: [ :x :k | x < 10 and: (#(a c g) includes: k) ].
 	self assert: actual equals: expected
+]
+
+{ #category : #tests }
+DataSeriesTest >> testWithoutNils [
+
+	| expected |
+	series := DataSeries
+		          withKeys: #( 1 2 'a' 3 )
+		          values: #( nil 4.2 'b' nil ).
+	expected := DataSeries withKeys: #( 2 'a' ) values: #( 4.2 'b' ).
+
+	self assert: series withoutNils equals: expected.
+	self deny: series equals: expected
+]
+
+{ #category : #tests }
+DataSeriesTest >> testWithoutNilsOnNamedSeries [
+
+	| expected |
+	series := DataSeries
+		          withKeys: #( 1 2 'a' 3 )
+		          values: #( nil 4.2 'b' nil )
+		          name: 'A'.
+	expected := DataSeries
+		            withKeys: #( 2 'a' )
+		            values: #( 4.2 'b' )
+		            name: 'A'.
+
+	self assert: series withoutNils equals: expected.
+	self deny: series equals: expected
 ]

--- a/src/DataFrame/DataSeries.class.st
+++ b/src/DataFrame/DataSeries.class.st
@@ -639,8 +639,12 @@ DataSeries >> removeDuplicates [
 { #category : #removing }
 DataSeries >> removeNils [
 	"Removes elements with nil values from the data series"
-	
-	^ self reject: [ :ele | ele isNil ]
+
+	| keysWithNilValues |
+	keysWithNilValues := OrderedCollection new.
+	self associationsDo: [ :each |
+		each value ifNil: [ keysWithNilValues add: each key ] ].
+	self removeKeys: keysWithNilValues
 ]
 
 { #category : #replacing }
@@ -1026,8 +1030,8 @@ DataSeries >> withSeries: otherDataSeries collect: twoArgBlock [
 
 { #category : #private }
 DataSeries >> withoutNils [
-	"Returns a data series without the elements whose values were nil values"
-	
+	"Returns a copy of the data series without the nil values"
+
 	^ self reject: #isNil
 ]
 


### PR DESCRIPTION
DataSeries>> #removeNils now removes nil values from a data series and #withoutNils returns a copy of the data series without nils.