### PR TITLE
add more formatting options to DataFrameCsvWriter

### DIFF
--- a/src/DataFrame-IO-Tests/DataFrameCsvWriterTest.class.st
+++ b/src/DataFrame-IO-Tests/DataFrameCsvWriterTest.class.st
@@ -56,6 +56,36 @@ DataFrameCsvWriterTest >> testWriteToCsvLineEndLf [
 ]
 
 { #category : #tests }
+DataFrameCsvWriterTest >> testWriteToCsvWithRawFieldWriter [
+
+	| file writer actual expected |
+	file := FileSystem memory workingDirectory / 'testData' / 'raw.csv'.
+	file ensureCreateFile.
+	writer := DataFrameCsvWriter new.
+	writer useRawFieldWriter.
+	dataFrame writeTo: file using: writer.
+	actual := self readFile: file.
+	expected := TestCsvStrings commaCsvString.
+	self assert: actual lines equals: expected lines
+]
+
+{ #category : #tests }
+DataFrameCsvWriterTest >> testWriteToCsvWithRawFieldWriterWithoutRowName [
+
+	| file writer actual expected |
+	file := FileSystem memory workingDirectory / 'testData' / 'raw.csv'.
+	file ensureCreateFile.
+	writer := DataFrameCsvWriter new.
+	writer
+		useRawFieldWriter;
+		disableRowName.
+	dataFrame writeTo: file using: writer.
+	actual := self readFile: file.
+	expected := TestCsvStrings commaCsvWithoutRowNameString.
+	self assert: actual lines equals: expected lines
+]
+
+{ #category : #tests }
 DataFrameCsvWriterTest >> testWriteToCsvWithSeparatorTab [
 	| actual expected |
 	dataFrame writeToCsv: tabQuoteCsvFile withSeparator: Character tab.

--- a/src/DataFrame-IO-Tests/TestCsvStrings.class.st
+++ b/src/DataFrame-IO-Tests/TestCsvStrings.class.st
@@ -16,6 +16,17 @@ TestCsvStrings class >> commaCsvString [
 ]
 
 { #category : #running }
+TestCsvStrings class >> commaCsvWithoutRowNameString [
+	^ 'temperature,precipitation,type
+2.4,true,rain
+0.5,true,rain
+-1.2,true,snow
+-2.3,false,-
+3.2,true,rain
+'
+]
+
+{ #category : #running }
 TestCsvStrings class >> commaQuoteCsvString [
 	^ '"","temperature","precipitation","type"
 "1:10 am","2.4","true","rain"

--- a/src/DataFrame-IO/DataFrameCsvWriter.class.st
+++ b/src/DataFrame-IO/DataFrameCsvWriter.class.st
@@ -3,10 +3,18 @@ Class {
 	#superclass : #DataFrameWriter,
 	#instVars : [
 		'separator',
-		'lineEndConvention'
+		'lineEndConvention',
+		'fieldWriter',
+		'rowNameEnabled'
 	],
 	#category : #'DataFrame-IO-Core'
 }
+
+{ #category : #'accessing - field writers' }
+DataFrameCsvWriter >> defaultFieldWriter [
+
+	^ nil
+]
 
 { #category : #accessing }
 DataFrameCsvWriter >> defaultLineEndConvention [
@@ -18,15 +26,48 @@ DataFrameCsvWriter >> defaultLineEndConvention [
 ]
 
 { #category : #accessing }
+DataFrameCsvWriter >> defaultRowIndexEnabled [
+
+	^ true
+]
+
+{ #category : #accessing }
 DataFrameCsvWriter >> defaultSeparator [
 	^ $,
 ]
 
+{ #category : #'enable/disable' }
+DataFrameCsvWriter >> disableRowName [
+
+	self rowNameEnabled: false
+]
+
+{ #category : #'enable/disable' }
+DataFrameCsvWriter >> enableRowName [
+
+	self rowNameEnabled: true
+]
+
+{ #category : #'accessing - field writers' }
+DataFrameCsvWriter >> fieldWriter [
+
+	^ fieldWriter
+]
+
+{ #category : #'accessing - field writers' }
+DataFrameCsvWriter >> fieldWriter: aSymbol [
+
+	fieldWriter := aSymbol
+]
+
 { #category : #initialization }
 DataFrameCsvWriter >> initialize [
+
 	super initialize.
 	separator := self defaultSeparator.
-	lineEndConvention := self defaultLineEndConvention
+	lineEndConvention := self defaultLineEndConvention.
+	fieldWriter := self defaultFieldWriter.
+	rowNameEnabled := self defaultRowIndexEnabled
 ]
 
 { #category : #accessing }
@@ -43,6 +84,42 @@ DataFrameCsvWriter >> lineEndConvention: aSymbol [
 	lineEndConvention := aSymbol
 ]
 
+{ #category : #'accessing - field writers' }
+DataFrameCsvWriter >> objectFieldWriter [
+
+	^ #object
+]
+
+{ #category : #'accessing - field writers' }
+DataFrameCsvWriter >> optionalQuotedFieldWriter [
+
+	^ #optionalQuoted
+]
+
+{ #category : #'accessing - field writers' }
+DataFrameCsvWriter >> quotedFieldWriter [
+
+	^ #quoted
+]
+
+{ #category : #'accessing - field writers' }
+DataFrameCsvWriter >> rawFieldWriter [
+
+	^ #raw
+]
+
+{ #category : #accessing }
+DataFrameCsvWriter >> rowNameEnabled [
+
+	^ rowNameEnabled
+]
+
+{ #category : #accessing }
+DataFrameCsvWriter >> rowNameEnabled: aBoolean [
+
+	rowNameEnabled := aBoolean = true
+]
+
 { #category : #accessing }
 DataFrameCsvWriter >> separator [
 	^ separator
@@ -53,25 +130,55 @@ DataFrameCsvWriter >> separator: anObject [
 	separator := anObject
 ]
 
+{ #category : #'accessing - field writers' }
+DataFrameCsvWriter >> useObjectFieldWriter [
+
+	self fieldWriter: self objectFieldWriter
+]
+
+{ #category : #'accessing - field writers' }
+DataFrameCsvWriter >> useOptionalQuotedFieldWriter [
+
+	self fieldWriter: self optionalQuotedFieldWriter
+]
+
+{ #category : #'accessing - field writers' }
+DataFrameCsvWriter >> useQuotedFieldWriter [
+
+	self fieldWriter: self quotedFieldWriter
+]
+
+{ #category : #'accessing - field writers' }
+DataFrameCsvWriter >> useRawFieldWriter [
+
+	self fieldWriter: self rawFieldWriter
+]
+
 { #category : #writing }
 DataFrameCsvWriter >> write: aDataFrame to: aFileReference [
+
 	| stream writer |
 	stream := aFileReference writeStream.
 
 	writer := NeoCSVWriter on: stream.
+	fieldWriter ifNotNil: [ writer fieldWriter: fieldWriter ].
 	writer separator: self separator.
 	writer lineEndConvention: self lineEndConvention.
 
-	writer
-		writeField: '';
-		writeSeparator;
-		writeHeader: aDataFrame columnNames.
-
-	aDataFrame do: [ :row |
+	self rowNameEnabled ifTrue: [
 		writer
-			writeField: row name;
-			writeSeparator;
-			nextPut: row ].
+			writeField: '';
+			writeSeparator ].
+	writer writeHeader: aDataFrame columnNames.
+
+	self rowNameEnabled
+		ifTrue: [
+			aDataFrame do: [ :row |
+				writer
+					writeField: row name;
+					writeSeparator;
+					nextPut: row ] ]
+		ifFalse: [ aDataFrame do: [ :row | writer nextPut: row ] ].
 
 	writer close
 ]


### PR DESCRIPTION
This PR is to provide more options to write CSV files in desired formats.

The inst var `fieldWriter` holds a symbol to be passed to NeoCSV writer to change the presentation of the values.
You can set it by `useRawFieldWriter`, `useQuotedFieldWriter`, `useOptionalQuotedFieldWriter` and `useObjectFieldWriter`.
By default, it uses the quoted field writer (same as the original implementation of the current `DataFrameCsvWriter`).

The inst var `rowNameEnabled` holds a boolean to decide whether the writer outputs row names into the CSV file.
You can set it by `enableRowName` and `disableRowName`.
By default, it is disabled (same as the original implementation of the current `DataFrameCsvWriter`).