### PR TITLE
Add method to read CSV string with option to skip N lines from header

### DIFF
--- a/src/DataFrame-IO-Tests/DataFrameCsvReaderTest.class.st
+++ b/src/DataFrame-IO-Tests/DataFrameCsvReaderTest.class.st
@@ -102,13 +102,13 @@ DataFrameCsvReaderTest >> testReadCsvWithSeparatorTab [
 { #category : #tests }
 DataFrameCsvReaderTest >> testReadCsvWithSeparatorTabSkip1 [
 
-	| doubleHeaderString actualDataFrame dataFrameWithoutFirstLine |
+	| doubleHeaderString controlDataFrame dataFrameWithoutFirstLine |
 
 	doubleHeaderString := 'a description header
 ' , TestCsvStrings tabCsvString.
-	actualDataFrame := DataFrame readFromCsv: doubleHeaderString withSeparator: Character tab skip: 1.
+	dataFrameWithoutFirstLine := DataFrame readFromCsv: doubleHeaderString withSeparator: Character tab skip: 1.
 
-	dataFrameWithoutFirstLine := DataFrame 
+	controlDataFrame := DataFrame 
 		withRows: #( 
 			#('1:10 am' '2.4' 'true' 'rain')
 			#('1:30 am' '0.5' 'true' 'rain') 
@@ -117,20 +117,20 @@ DataFrameCsvReaderTest >> testReadCsvWithSeparatorTabSkip1 [
 			#('2:30 am' '3.2' 'true' 'rain' ))
 		columnNames: #(nil temperature precipitation type ).
 
-	self assert: actualDataFrame equals: dataFrameWithoutFirstLine
+	self assert: controlDataFrame equals: dataFrameWithoutFirstLine
 ]
 
 { #category : #tests }
 DataFrameCsvReaderTest >> testReadCsvWithSeparatorTabSkipN [
 
-	| doubleHeaderString actualDataFrame dataFrameWithoutFirstLine |
+	| doubleHeaderString controlDataFrame dataFrameWithoutTwoFirstLines |
 
 	doubleHeaderString := 'a description header
 another description header
 ' , TestCsvStrings tabCsvString.
-	actualDataFrame := DataFrame readFromCsv: doubleHeaderString withSeparator: Character tab skip: 2.
+	dataFrameWithoutTwoFirstLines := DataFrame readFromCsv: doubleHeaderString withSeparator: Character tab skip: 2.
 
-	dataFrameWithoutFirstLine := DataFrame 
+	controlDataFrame := DataFrame 
 		withRows: #( 
 			#('1:10 am' '2.4' 'true' 'rain')
 			#('1:30 am' '0.5' 'true' 'rain') 
@@ -139,7 +139,7 @@ another description header
 			#('2:30 am' '3.2' 'true' 'rain' ))
 		columnNames: #(nil temperature precipitation type ).
 
-	self assert: actualDataFrame equals: dataFrameWithoutFirstLine
+	self assert: controlDataFrame equals: dataFrameWithoutTwoFirstLines
 ]
 
 { #category : #tests }

--- a/src/DataFrame-IO-Tests/DataFrameCsvReaderTest.class.st
+++ b/src/DataFrame-IO-Tests/DataFrameCsvReaderTest.class.st
@@ -100,6 +100,49 @@ DataFrameCsvReaderTest >> testReadCsvWithSeparatorTab [
 ]
 
 { #category : #tests }
+DataFrameCsvReaderTest >> testReadCsvWithSeparatorTabSkip1 [
+
+	| doubleHeaderString actualDataFrame dataFrameWithoutFirstLine |
+
+	doubleHeaderString := 'a description header
+' , TestCsvStrings tabCsvString.
+	actualDataFrame := DataFrame readFromCsv: doubleHeaderString withSeparator: Character tab skip: 1.
+
+	dataFrameWithoutFirstLine := DataFrame 
+		withRows: #( 
+			#('1:10 am' '2.4' 'true' 'rain')
+			#('1:30 am' '0.5' 'true' 'rain') 
+			#('1:50 am' '-1.2' 'true' 'snow') 
+			#('2:10 am' '-2.3' 'false' '-') 
+			#('2:30 am' '3.2' 'true' 'rain' ))
+		columnNames: #(nil temperature precipitation type ).
+
+	self assert: actualDataFrame equals: dataFrameWithoutFirstLine
+]
+
+{ #category : #tests }
+DataFrameCsvReaderTest >> testReadCsvWithSeparatorTabSkipN [
+
+	| doubleHeaderString actualDataFrame dataFrameWithoutFirstLine |
+
+	doubleHeaderString := 'a description header
+another description header
+' , TestCsvStrings tabCsvString.
+	actualDataFrame := DataFrame readFromCsv: doubleHeaderString withSeparator: Character tab skip: 2.
+
+	dataFrameWithoutFirstLine := DataFrame 
+		withRows: #( 
+			#('1:10 am' '2.4' 'true' 'rain')
+			#('1:30 am' '0.5' 'true' 'rain') 
+			#('1:50 am' '-1.2' 'true' 'snow') 
+			#('2:10 am' '-2.3' 'false' '-') 
+			#('2:30 am' '3.2' 'true' 'rain' ))
+		columnNames: #(nil temperature precipitation type ).
+
+	self assert: actualDataFrame equals: dataFrameWithoutFirstLine
+]
+
+{ #category : #tests }
 DataFrameCsvReaderTest >> testReadFromString [
 
 	| actualDataFrame |

--- a/src/DataFrame-IO/DataFrame.extension.st
+++ b/src/DataFrame-IO/DataFrame.extension.st
@@ -46,6 +46,18 @@ DataFrame class >> readFromCsv: aFileReference withSeparator: aSeparator [
 ]
 
 { #category : #'*DataFrame-IO' }
+DataFrame class >> readFromCsv: aFileReference withSeparator: aCharacter skip: anInteger [ 
+
+	| df reader |
+
+	reader := DataFrameCsvReader new.
+	df := reader readFromString: aFileReference withSeparator: aCharacter skip: anInteger.
+	df calculateDataTypes.
+	^ df
+
+]
+
+{ #category : #'*DataFrame-IO' }
 DataFrame class >> readFromCsvWithRowNames: aFileReference [
 	| reader |
 	reader := DataFrameCsvReader new.

--- a/src/DataFrame-IO/DataFrameCsvReader.class.st
+++ b/src/DataFrame-IO/DataFrameCsvReader.class.st
@@ -149,6 +149,23 @@ DataFrameCsvReader >> readFromString: aString withSeparator: aSeparator [
 ]
 
 { #category : #reading }
+DataFrameCsvReader >> readFromString: aCSVString withSeparator: aSeparator skip: nRows [
+	"Read data frame from aCSVString skipping nRows from its header"
+
+	| reader df |
+
+	reader := NeoCSVReader on: aCSVString readStream.
+	reader separator: aSeparator.
+	nRows timesRepeat: [ reader skipHeader ].
+
+	self readColumnNamesWith: reader.
+	self readRowsWith: reader.
+	reader close.
+	df := self createDataFrame.
+	^ df
+]
+
+{ #category : #reading }
 DataFrameCsvReader >> readFromString: aString withSeparator: aSeparator withHeader: hasHeader [
 	"Read data frame from aString"
 


### PR DESCRIPTION
This is commonly found in multiple CSV datasets (see for example See ftp://ftp.ncbi.nlm.nih.gov/genomes/README_assembly_summary.txt)
Add tests.


