### PR TITLE
Create DataFrame from CSV setting the column names and separator

### DIFF
--- a/src/DataFrame-IO-Tests/DataFrameCsvReaderTest.class.st
+++ b/src/DataFrame-IO-Tests/DataFrameCsvReaderTest.class.st
@@ -79,6 +79,28 @@ DataFrameCsvReaderTest >> testReadCsv [
 ]
 
 { #category : #tests }
+DataFrameCsvReaderTest >> testReadCsvWithColumnNamesWithSeparator [
+
+	| controlDataFrame customColumnNames |
+	
+	customColumnNames := #('Col1' 'Col2' 'Col3' 'Col4').
+
+	controlDataFrame := DataFrame 
+		readFromCsv: tabCsvFile 
+		withColumnNames: customColumnNames
+		separator: Character tab.
+
+	self 
+		assertCollection: controlDataFrame columnNames 
+		equals: customColumnNames asOrderedCollection.
+		
+	"The original header is counted as a normal row now"
+	self 
+		assert: controlDataFrame size 
+		equals: 6.
+]
+
+{ #category : #tests }
 DataFrameCsvReaderTest >> testReadCsvWithRowNames [
 	| actualDataFrame |
 	actualDataFrame := DataFrame readFromCsvWithRowNames: commaCsvFile.

--- a/src/DataFrame-IO/DataFrame.extension.st
+++ b/src/DataFrame-IO/DataFrame.extension.st
@@ -38,6 +38,19 @@ DataFrame class >> readFromCsv: aFileReference [
 ]
 
 { #category : #'*DataFrame-IO' }
+DataFrame class >> readFromCsv: aFileReference withColumnNames: anArrayOfColumnNames separator: aSeparator [
+
+	| dataFrame |
+
+	dataFrame := DataFrameCsvReader new
+		separator: aSeparator;
+		columnNames: anArrayOfColumnNames;
+		readFrom: aFileReference.
+	dataFrame calculateDataTypes.
+	^ dataFrame.
+]
+
+{ #category : #'*DataFrame-IO' }
 DataFrame class >> readFromCsv: aFileReference withSeparator: aSeparator [
 	| reader |
 	reader := DataFrameCsvReader new.

--- a/src/DataFrame-IO/DataFrameCsvReader.class.st
+++ b/src/DataFrame-IO/DataFrameCsvReader.class.st
@@ -43,6 +43,13 @@ Class {
 }
 
 { #category : #reading }
+DataFrameCsvReader >> columnNames: aCollectionOfString [
+	"Set the receiver' s column names"
+	
+	columnNames := aCollectionOfString
+]
+
+{ #category : #reading }
 DataFrameCsvReader >> createDataFrame [
 	| df |
 	df := DataFrame
@@ -91,7 +98,9 @@ DataFrameCsvReader >> initialize [
 
 { #category : #reading }
 DataFrameCsvReader >> readColumnNamesWith: aReader [
-	columnNames := aReader readHeader.
+	"Set the receiver's column names if they were not manually set"
+
+	columnNames ifNil: [ columnNames := aReader readHeader ].
 
 	self includeRowNames ifTrue: [
 		columnNames := columnNames copyWithoutFirst ]


### PR DESCRIPTION
This PR address the issue in #278, to enable reading from CSV file and manually setting the columns with a delimiter Character.
Now the data frame reader column names are not overwritten by default if they were previously set.
